### PR TITLE
[libs/plugins] - chore: add tags enum and make it required

### DIFF
--- a/libs/plugins/src/generators/fusion-app-generator/schema.d.ts
+++ b/libs/plugins/src/generators/fusion-app-generator/schema.d.ts
@@ -1,5 +1,5 @@
 export interface FusionAppGeneratorGeneratorSchema {
-    name: string;
-    tags?: string;
-    directory?: string;
+  name: string;
+  tags: 'ws' | 'pbi' | (string & unknown);
+  directory?: string;
 }

--- a/libs/plugins/src/generators/fusion-app-generator/schema.json
+++ b/libs/plugins/src/generators/fusion-app-generator/schema.json
@@ -2,7 +2,8 @@
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "$id": "FusionAppGenerator",
-  "title": "",
+  "title": "Create a Fusion Application",
+  "description": "Create a Fusion Application",
   "type": "object",
   "properties": {
     "name": {
@@ -16,13 +17,16 @@
     },
     "tags": {
       "type": "string",
-      "description": "Add tags to the project (used for linting)",
-      "alias": "t"
-    }, 
+      "alias": "t",
+      "description": "Use pbi if app is only PBI. Use ws if it's more than PBI",
+      "x-prompt": "Is it workspace or PBI only?",
+      "enum": ["pbi", "ws"],
+      "default": "ws"
+    },
     "directory": {
       "type": "string",
       "description": "A directory where the project is placed"
     }
   },
-  "required": ["name"]
+  "required": ["name", "tags"]
 }


### PR DESCRIPTION
# Description
When creating a new application, we want to add a specific tag to its config so we can figure out if it's only a PBI app or WS app. This info can later be used to bump versions for all pbi apps, or only WS apps.