### PR TITLE
[CI] - chore: remove legacy nx workspace lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: nrwl/nx-set-shas@v3
 
       - run: npm ci --legacy-peer-deps
-      - run: npx nx workspace-lint
       # - run: npx nx format:check
       - run: npx nx affected --target=lint --parallel=3
       - run: npx nx affected --target=test --parallel=3 --ci --code-coverage


### PR DESCRIPTION
# Description

nx workspace-lint is deprecated.
