### PR TITLE
feat: :sparkles: add autosize sidesheet width and remove margin-bottom: -15px from styledswitchboardwrapper

### DIFF
--- a/libs/electricalconsumersapp/src/lib/config/ElectricalSidesheet.tsx
+++ b/libs/electricalconsumersapp/src/lib/config/ElectricalSidesheet.tsx
@@ -1,4 +1,4 @@
-import { createWidget } from '@equinor/workspace-sidesheet';
+import { createWidget, useResizeContext } from '@equinor/workspace-sidesheet';
 import { ElectricalConsumer } from './workspaceConfig';
 import { useContextId, useHttpClient, ElectricalNetwork } from '@cc-components/shared';
 import {
@@ -14,7 +14,7 @@ import {
 } from '@cc-components/sharedcomponents';
 import { useQuery } from '@tanstack/react-query';
 import { SidesheetSkeleton } from '@cc-components/sharedcomponents';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Tabs } from '@equinor/eds-core-react';
 import { CircuitDiagramTab } from '../sidesheet/CircuitDiagramTab';
 
@@ -41,10 +41,17 @@ export function ElectricalInnerSidesheet({
   id: string;
   closeSidesheet: VoidFunction;
 }) {
+  const { width, setWidth } = useResizeContext();
   const [activeTab, setActiveTab] = useState(0);
   const handleChange = (index: number) => {
     setActiveTab(index);
   };
+  const reszied = useRef({ hasResized: false, id: id });
+  if (reszied.current.id !== id) {
+    reszied.current = { hasResized: false, id: id };
+    setWidth(700);
+  }
+
   const client = useHttpClient();
   const context = useContextId();
 
@@ -139,7 +146,19 @@ export function ElectricalInnerSidesheet({
 
         <StyledPanels>
           <Tabs.Panel>
-            <CircuitDiagramTab elenetwork={elenetwork} itemId={consumer.tagNo} />
+            <CircuitDiagramTab
+              elenetwork={elenetwork}
+              itemId={consumer.tagNo}
+              onCircuitDiagramReady={(element) => {
+                if (reszied.current.hasResized) return;
+                const newWidth = element.scrollWidth;
+                console.log(newWidth, element.clientWidth);
+                if (width !== 700) return;
+                console.log(width);
+                setWidth(newWidth + 50);
+                reszied.current = { hasResized: true, id: id };
+              }}
+            />
           </Tabs.Panel>
         </StyledPanels>
       </StyledTabs>

--- a/libs/electricalconsumersapp/src/lib/config/ElectricalSidesheet.tsx
+++ b/libs/electricalconsumersapp/src/lib/config/ElectricalSidesheet.tsx
@@ -152,9 +152,7 @@ export function ElectricalInnerSidesheet({
               onCircuitDiagramReady={(element) => {
                 if (reszied.current.hasResized) return;
                 const newWidth = element.scrollWidth;
-                console.log(newWidth, element.clientWidth);
                 if (width !== 700) return;
-                console.log(width);
                 setWidth(newWidth + 50);
                 reszied.current = { hasResized: true, id: id };
               }}

--- a/libs/electricalconsumersapp/src/lib/sidesheet/CircuitDiagramTab.tsx
+++ b/libs/electricalconsumersapp/src/lib/sidesheet/CircuitDiagramTab.tsx
@@ -3,8 +3,13 @@ import { CircuitDiagram, ElectricalNetwork } from '@cc-components/shared';
 type CircuitDiagramTabProps = {
   elenetwork?: ElectricalNetwork | null;
   itemId: string;
+  onCircuitDiagramReady?: (element: HTMLDivElement) => void;
 };
-export const CircuitDiagramTab = ({ elenetwork, itemId }: CircuitDiagramTabProps) => {
+export const CircuitDiagramTab = ({
+  elenetwork,
+  itemId,
+  onCircuitDiagramReady,
+}: CircuitDiagramTabProps) => {
   if (elenetwork === null) {
     return <div>No elenetwork found</div>;
   }
@@ -13,6 +18,7 @@ export const CircuitDiagramTab = ({ elenetwork, itemId }: CircuitDiagramTabProps
       network={elenetwork}
       isLoading={elenetwork === undefined}
       itemId={itemId}
+      onCircuitDiagramReady={onCircuitDiagramReady}
     />
   );
 };

--- a/libs/shared/src/packages/circuit-diagram/ui/CircuitDiagram.tsx
+++ b/libs/shared/src/packages/circuit-diagram/ui/CircuitDiagram.tsx
@@ -28,11 +28,13 @@ import {
   Transformer,
   Unknown,
 } from './CircuitDiagramComponents';
+import { on } from 'events';
 
 type CircuitDiagramProps = {
   network?: ElectricalNetwork;
   isLoading?: boolean;
   itemId: string;
+  onCircuitDiagramReady?: (element: HTMLDivElement) => void;
 };
 
 type ElectricalComponentProps = {
@@ -41,7 +43,12 @@ type ElectricalComponentProps = {
   itemId: string;
 };
 
-export function CircuitDiagram({ network, isLoading, itemId }: CircuitDiagramProps) {
+export function CircuitDiagram({
+  network,
+  isLoading,
+  itemId,
+  onCircuitDiagramReady,
+}: CircuitDiagramProps) {
   const [circuitRef, setCircuitRef] = useState<CircuitRef>({});
 
   if (!!isLoading || !network) {
@@ -49,7 +56,12 @@ export function CircuitDiagram({ network, isLoading, itemId }: CircuitDiagramPro
   }
   return (
     <StyledCircuitDiagramWrapper>
-      <StyledCircuitDiagram>
+      <StyledCircuitDiagram
+        ref={(element) => {
+          if (element === null || !onCircuitDiagramReady) return;
+          onCircuitDiagramReady(element);
+        }}
+      >
         <Switchboard network={network} circuitRef={circuitRef} />
         <StyledSwitchboardChildren>
           {network.children.map((circuit) => {

--- a/libs/shared/src/packages/circuit-diagram/ui/stylesCircuitDiagram.ts
+++ b/libs/shared/src/packages/circuit-diagram/ui/stylesCircuitDiagram.ts
@@ -9,7 +9,6 @@ export const StyledSwitchboardWrapper = styled.div`
   border: 1px solid ${tokens.colors.ui.background__medium.hex};
   gap: 5ch;
   padding: 10px 5px 0px 5px;
-  margin-bottom: -15px;
   border-radius: 10px;
   position: relative;
   align-items: center;


### PR DESCRIPTION
How to test: Open different sidesheets (circuit diagrams) in Electrical Consumers and check the sidesheet behavior. Expected behavior will be autosizing of the sidesheet witdh based on the citcuit diagram width, but minimum width will be the normal width of every sidesheet 