### PR TITLE
feat: allow sidesheet to draw over header

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@equinor/fusion-framework-react-app": "^4.1.8",
     "@equinor/fusion-framework-react-module-context": "^6.0.14",
     "@equinor/fusion-observable": "8.1.2",
-    "@equinor/workspace-fusion": "^6.0.12",
+    "@equinor/workspace-fusion": "^6.0.13",
     "@equinor/workspace-sidesheet": "^0.1.6",
     "@microsoft/applicationinsights-web": "^3.0.3",
     "@swc/helpers": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@equinor/fusion-framework-react-app": "^4.1.8",
     "@equinor/fusion-framework-react-module-context": "^6.0.14",
     "@equinor/fusion-observable": "8.1.2",
-    "@equinor/workspace-fusion": "^6.0.13",
+    "@equinor/workspace-fusion": "^6.0.14",
     "@equinor/workspace-sidesheet": "^0.1.6",
     "@microsoft/applicationinsights-web": "^3.0.3",
     "@swc/helpers": "0.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: 8.1.2
         version: 8.1.2(@types/react@18.2.22)(react@18.2.0)
       '@equinor/workspace-fusion':
-        specifier: ^6.0.12
-        version: 6.0.12(@ag-grid-enterprise/core@30.2.1)(@types/react@18.2.22)(react-dom@18.2.0)(react-is@18.2.0)(styled-components@5.3.6)(vite@4.4.9)
+        specifier: ^6.0.13
+        version: 6.0.13(@ag-grid-enterprise/core@30.2.1)(@types/react@18.2.22)(react-dom@18.2.0)(react-is@18.2.0)(styled-components@5.3.6)(vite@4.4.9)
       '@equinor/workspace-sidesheet':
         specifier: ^0.1.6
         version: 0.1.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
@@ -4675,8 +4675,8 @@ packages:
       - vite
     dev: false
 
-  /@equinor/workspace-fusion@6.0.12(@ag-grid-enterprise/core@30.2.1)(@types/react@18.2.22)(react-dom@18.2.0)(react-is@18.2.0)(styled-components@5.3.6)(vite@4.4.9):
-    resolution: {integrity: sha512-pf6ep4PfYsf1gsMmVT3qE4+EoRKDZjs1XcrJY3MtArtLXCtPtIDqOYKoBs+RP92Ze4s8Y/nizW1AtgoHKbU7sw==}
+  /@equinor/workspace-fusion@6.0.13(@ag-grid-enterprise/core@30.2.1)(@types/react@18.2.22)(react-dom@18.2.0)(react-is@18.2.0)(styled-components@5.3.6)(vite@4.4.9):
+    resolution: {integrity: sha512-ZbDkZt9a1a0w5YSkSBVZ6EhCTmH677S97UpPmhu6ole8zFNEtaQePSrmE69tBx7oUDSOGNWAwNt7opMHAttY6A==}
     peerDependencies:
       react-dom: '>= 16.8.0 || 18'
       react-is: '>= 16.8.0'
@@ -4692,7 +4692,7 @@ packages:
       '@equinor/workspace-filter': 3.0.7(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
       '@equinor/workspace-garden': 6.0.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
       '@equinor/workspace-powerbi': 1.0.10(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
-      '@equinor/workspace-react': 1.0.4(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
+      '@equinor/workspace-react': 1.0.5(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
       '@tanstack/react-query': 4.35.3(react-dom@18.2.0)(react@18.2.0)
       '@types/react-dom': 18.2.7
       react: 18.2.0
@@ -4941,6 +4941,33 @@ packages:
 
   /@equinor/workspace-react@1.0.4(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6):
     resolution: {integrity: sha512-l++UvZPSkoNOWIsbUjzON1ke6GEAaPsknKtVDG2xoPD30JVteMFChi/CnP4UbFHYWJk7bXXCdALtZv2xlbL9BA==}
+    peerDependencies:
+      react: '>= 16.8.0 || 18'
+      react-dom: '>= 16.8.0 || 18'
+      react-is: '>= 16.8.0'
+      styled-components: ^5.3.6
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@equinor/eds-core-react': 0.28.0(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.6)
+      '@equinor/eds-icons': 0.18.0
+      '@equinor/eds-tokens': 0.9.2
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-is: 18.2.0
+      styled-components: 5.3.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+      zustand: 4.3.7(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - immer
+      - supports-color
+    dev: false
+
+  /@equinor/workspace-react@1.0.5(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6):
+    resolution: {integrity: sha512-HmyWQyjj7Gl5PJIlg5YFjK88c17zIIJIXCbPtSsMIDAPsDqMQDLtWrAVbyXnjnx3Q61mHoc6DGEVR2OJnUeZ2g==}
     peerDependencies:
       react: '>= 16.8.0 || 18'
       react-dom: '>= 16.8.0 || 18'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: 8.1.2
         version: 8.1.2(@types/react@18.2.22)(react@18.2.0)
       '@equinor/workspace-fusion':
-        specifier: ^6.0.13
-        version: 6.0.13(@ag-grid-enterprise/core@30.2.1)(@types/react@18.2.22)(react-dom@18.2.0)(react-is@18.2.0)(styled-components@5.3.6)(vite@4.4.9)
+        specifier: ^6.0.14
+        version: 6.0.14(@ag-grid-enterprise/core@30.2.1)(@types/react@18.2.22)(react-dom@18.2.0)(react-is@18.2.0)(styled-components@5.3.6)(vite@4.4.9)
       '@equinor/workspace-sidesheet':
         specifier: ^0.1.6
         version: 0.1.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
@@ -4675,8 +4675,8 @@ packages:
       - vite
     dev: false
 
-  /@equinor/workspace-fusion@6.0.13(@ag-grid-enterprise/core@30.2.1)(@types/react@18.2.22)(react-dom@18.2.0)(react-is@18.2.0)(styled-components@5.3.6)(vite@4.4.9):
-    resolution: {integrity: sha512-ZbDkZt9a1a0w5YSkSBVZ6EhCTmH677S97UpPmhu6ole8zFNEtaQePSrmE69tBx7oUDSOGNWAwNt7opMHAttY6A==}
+  /@equinor/workspace-fusion@6.0.14(@ag-grid-enterprise/core@30.2.1)(@types/react@18.2.22)(react-dom@18.2.0)(react-is@18.2.0)(styled-components@5.3.6)(vite@4.4.9):
+    resolution: {integrity: sha512-9kEr8Sa3pSI+nQsK9TeniP/NtOnGoTqS0jbaYh190F27hqyC88uKVXtmvqbIEPn2l8XYfeMe9539tjttJL70cA==}
     peerDependencies:
       react-dom: '>= 16.8.0 || 18'
       react-is: '>= 16.8.0'
@@ -4692,7 +4692,7 @@ packages:
       '@equinor/workspace-filter': 3.0.7(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
       '@equinor/workspace-garden': 6.0.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
       '@equinor/workspace-powerbi': 1.0.10(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
-      '@equinor/workspace-react': 1.0.5(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
+      '@equinor/workspace-react': 1.0.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6)
       '@tanstack/react-query': 4.35.3(react-dom@18.2.0)(react@18.2.0)
       '@types/react-dom': 18.2.7
       react: 18.2.0
@@ -4966,8 +4966,8 @@ packages:
       - supports-color
     dev: false
 
-  /@equinor/workspace-react@1.0.5(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6):
-    resolution: {integrity: sha512-HmyWQyjj7Gl5PJIlg5YFjK88c17zIIJIXCbPtSsMIDAPsDqMQDLtWrAVbyXnjnx3Q61mHoc6DGEVR2OJnUeZ2g==}
+  /@equinor/workspace-react@1.0.6(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.6):
+    resolution: {integrity: sha512-DgWOqFGx9vL++n2hTKCLVyp3tCoPXs1rks66V/WBfceBCsp7Rs1Saz6Kr6wT38SiQm0UTr8zLj7Jvn5/pQ3YKw==}
     peerDependencies:
       react: '>= 16.8.0 || 18'
       react-dom: '>= 16.8.0 || 18'


### PR DESCRIPTION
Css fix in fusion-workspace allows the sidesheet to draw over topbar without interrupting the filters/navigation/kpi'

- [x] equinor/fusion-workspace#528