### PR TITLE
ci: fix deploy script

### DIFF
--- a/.github/workflows/create-fusion-app.yml
+++ b/.github/workflows/create-fusion-app.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: 'Create application in Fusion CI'
         shell: bash
-        run: npx ts-node --esm ./github-action/src/createFusionApp.ts create -T ${{ steps.get-fusion-token-ci.outputs.token }} -A '${{inputs.appKey}}' -C '${{inputs.category}}' -D '${{inputs.displayName}}' -O '${{vars.FUSION_APP_ADMINS_CI}}' -E 'CI'
+        run: npx tsx ./github-action/src/createFusionApp.ts create -T ${{ steps.get-fusion-token-ci.outputs.token }} -A '${{inputs.appKey}}' -C '${{inputs.category}}' -D '${{inputs.displayName}}' -O '${{vars.FUSION_APP_ADMINS_CI}}' -E 'CI'
 
   create-fusion-app-fprd:
     runs-on: ubuntu-latest
@@ -84,4 +84,4 @@ jobs:
 
       - name: 'Create application in Fusion FPRD'
         shell: bash
-        run: npx ts-node --esm ./github-action/src/createFusionApp.ts create -T ${{ steps.get-fusion-token-fprd.outputs.token }} -A '${{inputs.appKey}}' -C '${{inputs.category}}' -D '${{inputs.displayName}}' -O '${{vars.FUSION_APP_ADMINS_FPRD}}'  -E 'FPRD'
+        run: npx tsx ./github-action/src/createFusionApp.ts create -T ${{ steps.get-fusion-token-fprd.outputs.token }} -A '${{inputs.appKey}}' -C '${{inputs.category}}' -D '${{inputs.displayName}}' -O '${{vars.FUSION_APP_ADMINS_FPRD}}'  -E 'FPRD'

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: 'Update issue'
         shell: bash
-        run: npx ts-node --esm ./github-action/src/issue.ts issue -T ${{ github.token }} -C ${{steps.get-fusion-token-ci.outputs.token}} -F ${{steps.get-fusion-token-fprd.outputs.token}}
+        run: npx tsx ./github-action/src/issue.ts issue -T ${{ github.token }} -C ${{steps.get-fusion-token-ci.outputs.token}} -F ${{steps.get-fusion-token-fprd.outputs.token}}

--- a/apps/electricalconsumers/package.json
+++ b/apps/electricalconsumers/package.json
@@ -9,8 +9,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/electricalconsumersapp": "workspace:^",

--- a/apps/handover/package.json
+++ b/apps/handover/package.json
@@ -8,8 +8,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/handoverapp": "workspace:^",

--- a/apps/heattrace/package.json
+++ b/apps/heattrace/package.json
@@ -10,8 +10,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/heattraceapp": "workspace:^",

--- a/apps/loop/package.json
+++ b/apps/loop/package.json
@@ -8,8 +8,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/loopapp": "workspace:^",

--- a/apps/mechanicalcompletion/package.json
+++ b/apps/mechanicalcompletion/package.json
@@ -10,8 +10,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "tsx --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "tsx --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/mechanicalcompletionapp": "workspace:^",

--- a/apps/mechanicalcompletion/package.json
+++ b/apps/mechanicalcompletion/package.json
@@ -10,8 +10,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx --esm ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx --esm ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/mechanicalcompletionapp": "workspace:^",

--- a/apps/piping/package.json
+++ b/apps/piping/package.json
@@ -9,8 +9,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/pipingapp": "workspace:^",

--- a/apps/punch/package.json
+++ b/apps/punch/package.json
@@ -8,8 +8,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/punchapp": "workspace:^",

--- a/apps/scopechangerequest/package.json
+++ b/apps/scopechangerequest/package.json
@@ -9,8 +9,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/scopechangerequestapp": "workspace:^",

--- a/apps/swcr/package.json
+++ b/apps/swcr/package.json
@@ -9,8 +9,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/shared": "workspace:^",

--- a/apps/workorder/package.json
+++ b/apps/workorder/package.json
@@ -7,8 +7,8 @@
     "dev": "fusion-framework-cli app dev",
     "dev:local": "fusion-framework-cli app dev -c app.config.local.js",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/shared": "workspace:^",

--- a/libs/plugins/src/generators/fusion-app-generator/files/package.json__template__
+++ b/libs/plugins/src/generators/fusion-app-generator/files/package.json__template__
@@ -7,8 +7,8 @@
   "scripts": {
     "dev": "fusion-framework-cli app dev",
     "build": "tsc -b -f",
-    "pr:deploy": "ts-node --esm ../../github-action/src/releasePr.ts release",
-    "fprd:deploy": "ts-node --esm ../../github-action/src/releaseMain.ts release"
+    "pr:deploy": "tsx ../../github-action/src/releasePr.ts release",
+    "fprd:deploy": "tsx ../../github-action/src/releaseMain.ts release"
   },
   "dependencies": {
     "@cc-components/<%= projectName%>app": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "nx": "15.7.1",
     "rollup-plugin-inject-process-env": "^1.3.1",
     "ts-node": "^10.9.1",
+    "tsx": "^4.6.2",
     "turbo": "^1.10.14",
     "typescript": "~5.2.2",
     "vite": "^5.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.3.89)(@types/node@20.7.0)(typescript@5.2.2)
+      tsx:
+        specifier: ^4.6.2
+        version: 4.6.2
       turbo:
         specifier: ^1.10.14
         version: 1.10.14
@@ -12418,6 +12421,12 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
 
+  /get-tsconfig@4.7.2:
+    resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
+
   /github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
     dev: false
@@ -15990,6 +15999,10 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /resolve@0.6.3:
     resolution: {integrity: sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==}
     dev: false
@@ -17063,6 +17076,17 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  /tsx@4.6.2:
+    resolution: {integrity: sha512-QPpBdJo+ZDtqZgAnq86iY/PD2KYCUPSUGIunHdGwyII99GKH+f3z3FZ8XNFLSGQIA4I365ui8wnQpl8OKLqcsg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.18.20
+      get-tsconfig: 4.7.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
 
   /tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}


### PR DESCRIPTION
ts-node randomly fails with unknown file extension .ts. Which is usually caused by a missing --esm flag. This is not the case and it only randomly happens so I found it easier to just replace with tsx
