### PR TITLE
feat: :sparkles: remaining hours garden header

### DIFF
--- a/libs/workorderapp/src/lib/ui-garden/Header.tsx
+++ b/libs/workorderapp/src/lib/ui-garden/Header.tsx
@@ -2,19 +2,21 @@ import { CustomHeaderView } from '@equinor/workspace-fusion/garden';
 import { memo } from 'react';
 import styled from 'styled-components';
 
-const HeaderContent = styled.div`
+const StyledHeaderContent = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
   font-weight: 600;
 `;
-const Count = styled.h2`
+
+const StyledCount = styled.h2`
   color: #000000;
   font-weight: 300;
   font-size: 0.8rem;
   margin-left: 0.8em;
 `;
+
 const StyledHeaderText = styled.h2`
   white-space: pre-line;
   font-size: 16px;
@@ -24,10 +26,10 @@ const WorkOrderHeader = (props: CustomHeaderView) => {
   const { header } = props;
 
   return (
-    <HeaderContent>
+    <StyledHeaderContent>
       <StyledHeaderText>{header.name}</StyledHeaderText>
-      <Count>({header.count})</Count>
-    </HeaderContent>
+      <StyledCount>({header.count})</StyledCount>
+    </StyledHeaderContent>
   );
 };
 

--- a/libs/workorderapp/src/lib/ui-garden/Header.tsx
+++ b/libs/workorderapp/src/lib/ui-garden/Header.tsx
@@ -9,18 +9,23 @@ const HeaderContent = styled.div`
   align-items: center;
   font-weight: 600;
 `;
-const Count = styled.span`
+const Count = styled.h2`
   color: #000000;
   font-weight: 300;
   font-size: 0.8rem;
   margin-left: 0.8em;
 `;
+const StyledHeaderText = styled.h2`
+  white-space: pre-line;
+  font-size: 16px;
+`;
+
 const WorkOrderHeader = (props: CustomHeaderView) => {
   const { header } = props;
 
   return (
     <HeaderContent>
-      <div style={{ whiteSpace: 'pre-line' }}>{header.name}</div>
+      <StyledHeaderText>{header.name}</StyledHeaderText>
       <Count>({header.count})</Count>
     </HeaderContent>
   );

--- a/libs/workorderapp/src/lib/ui-garden/Header.tsx
+++ b/libs/workorderapp/src/lib/ui-garden/Header.tsx
@@ -20,10 +20,7 @@ const WorkOrderHeader = (props: CustomHeaderView) => {
 
   return (
     <HeaderContent>
-      <div>
-        {header.name}
-        <div>{''}</div>
-      </div>
+      <div style={{ whiteSpace: 'pre-line' }}>{header.name}</div>
       <Count>({header.count})</Count>
     </HeaderContent>
   );


### PR DESCRIPTION
- [x] Remaining hours in garden header

Using css and `\n` to solve this without breaking changes

equinor/fusion-data-gateway#428



![image](https://github.com/equinor/cc-components/assets/89254170/23123c0f-025c-4ab0-af2e-5601422ea6f9)
