### PR TITLE
🎁: Added missing Pipetest fields to Grid

### DIFF
--- a/libs/pipingapp/src/lib/config/tableConfig.tsx
+++ b/libs/pipingapp/src/lib/config/tableConfig.tsx
@@ -127,13 +127,13 @@ const columnDefinitions: [ColDef<Pipetest>, ...ColDef<Pipetest>[]] = [
   },
   {
     headerName: domainNames.commIdentifier,
-    colId: 'commIdentifier',
-    valueGetter: (element) => '', // TODO: Add this once it is ready in the backend
+    colId: 'commissioningIdentifierCode',
+    valueGetter: (element) => element.data?.commissioningIdentifierCode,
   },
   {
     headerName: 'MC Handover Status',
     colId: 'mechanicalCompletionHandoverStatus',
-    valueGetter: (element) => '', // TODO: Add this once it is ready in the backend
+    valueGetter: (element) => element.data?.mechanicalCompletionHandoverStatus,
   },
   {
     headerName: domainNames.mcResponsible,
@@ -143,7 +143,7 @@ const columnDefinitions: [ColDef<Pipetest>, ...ColDef<Pipetest>[]] = [
   {
     headerName: domainNames.mcPhase,
     colId: 'mechanicalCompletionPhase',
-    valueGetter: (element) => '', // TODO: Add this once it is ready in the backend
+    valueGetter: (element) => element.data?.mechanicalCompletionPhase,
   },
   {
     headerName: 'HT cables',

--- a/libs/pipingshared/src/lib/types/pipetest.ts
+++ b/libs/pipingshared/src/lib/types/pipetest.ts
@@ -12,11 +12,14 @@ export type Pipetest = {
   mechanicalCompletionUrlId: string;
   mechanicalCompletionResponsible: string;
   mechanicalCompletionStatus: string;
+  mechanicalCompletionHandoverStatus: string;
+  mechanicalCompletionPhase: string;
   mechanicalCompletionId: string;
   commissioningPackageUrlId: string;
   commissioningResponsible: string;
   commissioningStatus: string;
   commissioningPackageNo: string;
+  commissioningIdentifierCode: string;
   dueDateTimePeriod: string;
   isOverdue: string;
   checklistStep: string;


### PR DESCRIPTION
Added missing Pipetest fields to Grid.

Implements equinor/fusion-data-gateway#468

Relies on the back-end PR: 
https://github.com/equinor/fusion-data-gateway/pull/492