### PR TITLE
🐛 Fixed Overflow issue Report Access Error (Access control description)

### DIFF
--- a/libs/shared/src/packages/pbi-helpers/src/lib/error-component/AccessErrorComponent.tsx
+++ b/libs/shared/src/packages/pbi-helpers/src/lib/error-component/AccessErrorComponent.tsx
@@ -91,7 +91,7 @@ export const AccessErrorComponent = (props: Props) => {
           <Accordion>
             <Accordion.Item>
               <Accordion.Header>Access control description</Accordion.Header>
-              <Accordion.Panel>
+              <Accordion.Panel style={{ overflow: 'auto' }}>
                 <Markdown>{data.errorMessage}</Markdown>
               </Accordion.Panel>
             </Accordion.Item>


### PR DESCRIPTION
Fixed issue with overflowing text in Access Control Description, by adding scrollbar.
Related to equinor/fusion-workspace#551

**Screenshot of Bug:**
![image](https://github.com/equinor/cc-components/assets/17578087/4a8c9080-c614-4929-b11c-699d27f36768)

