### PR TITLE
fix: EDS styling errors

### DIFF
--- a/libs/shared/src/packages/common/src/lib/popover/popover.styles.ts
+++ b/libs/shared/src/packages/common/src/lib/popover/popover.styles.ts
@@ -17,12 +17,6 @@ export const StyledPopoverContainer = styled.div`
     margin: 0;
     font-size: 12px;
   }
-  *:first-child {
-    padding-top: 0;
-  }
-  *:last-child {
-    padding-bottom: 0;
-  }
 `;
 
 export const StyledPopoverProjectTitle = styled.p`

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   },
   "dependencies": {
     "@ag-grid-enterprise/core": "31.2.1",
-    "@equinor/eds-core-react": "^0.28.0",
-    "@equinor/eds-icons": "0.19.3",
+    "@equinor/eds-core-react": "^0.37.0",
+    "@equinor/eds-icons": "0.21.0",
     "@equinor/eds-tokens": "0.9.2",
     "@equinor/fusion-framework-module": "^4.3.0",
     "@equinor/fusion-framework-module-ag-grid": "31.2.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@equinor/fusion-framework-react-module-context": "^6.2.3",
     "@equinor/fusion-framework-react-module-http": "^5.0.3",
     "@equinor/fusion-observable": "8.3.0",
-    "@equinor/workspace-fusion": "9.0.4",
+    "@equinor/workspace-fusion": "9.0.6-pr.0",
     "@microsoft/applicationinsights-web": "^3.2.0",
     "@swc/helpers": "0.5.11",
     "@tanstack/react-query": "^5.32.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@equinor/fusion-framework-react-module-context": "^6.2.3",
     "@equinor/fusion-framework-react-module-http": "^5.0.3",
     "@equinor/fusion-observable": "8.3.0",
-    "@equinor/workspace-fusion": "9.0.6-pr.0",
+    "@equinor/workspace-fusion": "9.0.6",
     "@microsoft/applicationinsights-web": "^3.2.0",
     "@swc/helpers": "0.5.11",
     "@tanstack/react-query": "^5.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: 8.3.0
         version: 8.3.0(@types/react@18.2.22)(react@18.2.0)
       '@equinor/workspace-fusion':
-        specifier: 9.0.4
-        version: 9.0.4(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@babel/core@7.23.2)(@types/react@18.2.22)(@types/sortablejs@1.15.8)(immer@9.0.21)(react-is@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.2.10(@types/node@20.12.7))
+        specifier: 9.0.6-pr.0
+        version: 9.0.6-pr.0(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@babel/core@7.24.4)(@types/react@18.2.22)(@types/sortablejs@1.15.8)(immer@9.0.21)(react-is@18.2.0)
       '@microsoft/applicationinsights-web':
         specifier: ^3.2.0
         version: 3.2.0(tslib@2.6.2)
@@ -1659,14 +1659,6 @@ packages:
       lodash: ^4.17.21
       three: 0.158.0
 
-  '@equinor/eds-core-react@0.27.0':
-    resolution: {integrity: sha512-mbcc0B7fZLxWT0De6bI+DFUQUJ+y1M8zEtVFQDwLu9++n8+8odwNbTN/TsT/97VP5cea0xmtZpHRFA6ix4oCnw==}
-    engines: {node: '>=10.0.0', pnpm: '>=4'}
-    peerDependencies:
-      react: 18.2.0
-      react-dom: 18.2.0
-      styled-components: '>=4.2'
-
   '@equinor/eds-core-react@0.28.0':
     resolution: {integrity: sha512-hCIgjjPa4c6lEKE9vfb7zrV1eFHrrPcsTRr6cdTzt5JHyu+hAlHx+mk7nUPn9yDN+2dGV8xQBIKrCeDuX1w5eQ==}
     engines: {node: '>=10.0.0', pnpm: '>=4'}
@@ -1682,10 +1674,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0
       styled-components: '>=4.2'
-
-  '@equinor/eds-icons@0.16.0':
-    resolution: {integrity: sha512-ByEJLYaTMAoxRGpiyB/pSY/cfsXdiQ4TvQR0H4jaiWeDat/wYSZPWkA0tImo80As9iczTV8uC7iXCF7ZrY4KQA==}
-    engines: {node: '>=10.0.0', pnpm: '>=4'}
 
   '@equinor/eds-icons@0.17.0':
     resolution: {integrity: sha512-Nhd/3rPS5l6IE+BN+fd1Om1yjS71CSMCCqWaXe3dVNPfkAG/ARIiG72+S4Rcjb1d5Qbn1bppNCUL26O5dlKrCw==}
@@ -2025,10 +2013,8 @@ packages:
       react-is: '>= 16.8.0'
       styled-components: ^5.3.5
 
-  '@equinor/workspace-fusion@9.0.4':
-    resolution: {integrity: sha512-EmJy0Oo81nb59Qv1LwNS5wj13cY1I55gibyREHTmt4KR29j7q7sHiK839eos0R3741acDJx1qMaE420YxU0yOA==}
-    peerDependencies:
-      styled-components: '>= 5'
+  '@equinor/workspace-fusion@9.0.6-pr.0':
+    resolution: {integrity: sha512-GBRGm10J2+nkckyT+z62a5RwfvHJp257Zu750aYqPA8Wpgp07V3AOlFV4nsgy7N/fJjszedcD7hUcBZM8TmfXA==}
 
   '@equinor/workspace-garden@8.0.1':
     resolution: {integrity: sha512-mDqqJ2SZRPZyvIScc6rqYfmfOxte1tlnPHf8hc2aj4ZUoypg9MSKo0903B04nQi4gT/VOLhDGDsTy5MNFPZ5Pw==}
@@ -2038,13 +2024,8 @@ packages:
       react-is: '>= 16.8.0'
       styled-components: ^5.3.6
 
-  '@equinor/workspace-powerbi@3.0.1':
-    resolution: {integrity: sha512-1Vx7u0DPTpGheZDHi0W9j6FsqQJDMbMA3ijpY7Cb7g80W6NKTIh7Qna3Qj7GLzYnJ1+392JkLXdR7sXvO2kmYA==}
-    peerDependencies:
-      react: 18.2.0
-      react-dom: 18.2.0
-      react-is: '>= 16.8.0'
-      styled-components: ^5.3.5
+  '@equinor/workspace-powerbi@3.0.3-pr.1':
+    resolution: {integrity: sha512-WrUg8bCsc7scJ+jy1EwDRD9AXddT6eF7tIW8gRjMZ4m0Co4h2FD5bL7JP+qUVbCwaK77D4o88vLu7JKb47t4Jg==}
 
   '@equinor/workspace-react@2.0.1':
     resolution: {integrity: sha512-EMOJU9XL7iVJfMXqcu8d1PjTK6Wblwy2hee9NlS7HNwbhvMy4bvmKV1civu4k5He8bBPfq/9s6XOy0vU63NfLg==}
@@ -9368,6 +9349,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.4)':
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10211,37 +10197,6 @@ snapshots:
       lodash: 4.17.21
       three: 0.154.0
 
-  '@equinor/eds-core-react@0.27.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
-    dependencies:
-      '@babel/runtime': 7.24.4
-      '@equinor/eds-icons': 0.16.0
-      '@equinor/eds-tokens': 0.9.0
-      '@equinor/eds-utils': 0.7.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      '@floating-ui/react-dom-interactions': 0.10.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      downshift: 7.6.0(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-components: 6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  '@equinor/eds-core-react@0.28.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
-    dependencies:
-      '@babel/runtime': 7.23.2
-      '@equinor/eds-icons': 0.17.0
-      '@equinor/eds-tokens': 0.9.0
-      '@equinor/eds-utils': 0.7.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      '@floating-ui/react-dom-interactions': 0.10.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@tanstack/react-virtual': 3.0.0-beta.30(react@18.2.0)
-      downshift: 7.6.0(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-components: 6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   '@equinor/eds-core-react@0.28.0(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.23.2
@@ -10254,6 +10209,22 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       styled-components: 6.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@equinor/eds-core-react@0.28.0(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@equinor/eds-icons': 0.17.0
+      '@equinor/eds-tokens': 0.9.0
+      '@equinor/eds-utils': 0.7.0(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@floating-ui/react-dom-interactions': 0.10.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/react-virtual': 3.0.0-beta.30(react@18.2.0)
+      downshift: 7.6.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-components: 6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -10277,8 +10248,6 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       styled-components: 6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@equinor/eds-icons@0.16.0': {}
-
   '@equinor/eds-icons@0.17.0': {}
 
   '@equinor/eds-icons@0.18.0': {}
@@ -10291,20 +10260,6 @@ snapshots:
 
   '@equinor/eds-tokens@0.9.2': {}
 
-  '@equinor/eds-utils@0.7.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
-    dependencies:
-      '@babel/runtime': 7.23.2
-      '@equinor/eds-tokens': 0.9.0
-      '@popperjs/core': 2.11.6
-      babel-jest: 29.5.0(@babel/core@7.23.2)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-popper: 2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      styled-components: 6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   '@equinor/eds-utils@0.7.0(@babel/core@7.23.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@babel/runtime': 7.23.2
@@ -10315,6 +10270,20 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-popper: 2.3.0(@popperjs/core@2.11.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       styled-components: 6.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@equinor/eds-utils@0.7.0(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@equinor/eds-tokens': 0.9.0
+      '@popperjs/core': 2.11.6
+      babel-jest: 29.5.0(@babel/core@7.24.4)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-popper: 2.3.0(@popperjs/core@2.11.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      styled-components: 6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -11064,9 +11033,9 @@ snapshots:
       - '@ag-grid-community/styles'
       - '@types/react'
 
-  '@equinor/workspace-filter@4.0.3(@babel/core@7.23.2)(@types/sortablejs@1.15.8)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@equinor/workspace-filter@4.0.3(@babel/core@7.24.4)(@types/sortablejs@1.15.8)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@equinor/eds-core-react': 0.28.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@equinor/eds-core-react': 0.28.0(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@equinor/eds-icons': 0.18.0
       '@equinor/eds-tokens': 0.9.2
       '@tanstack/react-query': 5.32.0(react@18.2.0)
@@ -11083,23 +11052,22 @@ snapshots:
       - '@types/sortablejs'
       - supports-color
 
-  '@equinor/workspace-fusion@9.0.4(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@babel/core@7.23.2)(@types/react@18.2.22)(@types/sortablejs@1.15.8)(immer@9.0.21)(react-is@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.2.10(@types/node@20.12.7))':
+  '@equinor/workspace-fusion@9.0.6-pr.0(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@babel/core@7.24.4)(@types/react@18.2.22)(@types/sortablejs@1.15.8)(immer@9.0.21)(react-is@18.2.0)':
     dependencies:
-      '@equinor/eds-core-react': 0.27.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      '@equinor/eds-icons': 0.17.0
-      '@equinor/eds-tokens': 0.9.0
+      '@equinor/eds-core-react': 0.37.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@equinor/eds-icons': 0.21.0
+      '@equinor/eds-tokens': 0.9.2
       '@equinor/workspace-ag-grid': 3.0.2(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@types/react@18.2.22)(react-is@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      '@equinor/workspace-filter': 4.0.3(@babel/core@7.23.2)(@types/sortablejs@1.15.8)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      '@equinor/workspace-garden': 8.0.1(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      '@equinor/workspace-powerbi': 3.0.1(@babel/core@7.23.2)(@types/sortablejs@1.15.8)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      '@equinor/workspace-react': 2.0.1(@babel/core@7.23.2)(@types/react@18.2.22)(immer@9.0.21)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@equinor/workspace-filter': 4.0.3(@babel/core@7.24.4)(@types/sortablejs@1.15.8)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@equinor/workspace-garden': 8.0.1(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@equinor/workspace-powerbi': 3.0.3-pr.1(@types/sortablejs@1.15.8)
+      '@equinor/workspace-react': 2.0.1(@babel/core@7.24.4)(@types/react@18.2.22)(immer@9.0.21)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@tanstack/react-query': 5.32.0(react@18.2.0)
       re-resizable: 6.9.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-error-boundary: 4.0.13(react@18.2.0)
       styled-components: 6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      vite-plugin-environment: 1.1.3(vite@5.2.10(@types/node@20.12.7))
     transitivePeerDependencies:
       - '@ag-grid-community/styles'
       - '@ag-grid-enterprise/core'
@@ -11109,11 +11077,10 @@ snapshots:
       - immer
       - react-is
       - supports-color
-      - vite
 
-  '@equinor/workspace-garden@8.0.1(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@equinor/workspace-garden@8.0.1(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@equinor/eds-core-react': 0.28.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@equinor/eds-core-react': 0.28.0(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@equinor/eds-icons': 0.18.0
       '@equinor/eds-tokens': 0.9.0
       '@tanstack/react-query': 5.32.0(react@18.2.0)
@@ -11128,10 +11095,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@equinor/workspace-powerbi@3.0.1(@babel/core@7.23.2)(@types/sortablejs@1.15.8)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@equinor/workspace-powerbi@3.0.3-pr.1(@types/sortablejs@1.15.8)':
     dependencies:
-      '@equinor/eds-core-react': 0.28.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      '@equinor/eds-icons': 0.18.0
+      '@equinor/eds-core-react': 0.37.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@equinor/eds-icons': 0.21.0
       '@equinor/eds-tokens': 0.9.2
       '@tanstack/react-query': 5.32.0(react@18.2.0)
       markdown-to-jsx: 7.4.7(react@18.2.0)
@@ -11146,13 +11113,11 @@ snapshots:
       sortablejs: 1.15.2
       styled-components: 6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
-      - '@babel/core'
       - '@types/sortablejs'
-      - supports-color
 
-  '@equinor/workspace-react@2.0.1(@babel/core@7.23.2)(@types/react@18.2.22)(immer@9.0.21)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@equinor/workspace-react@2.0.1(@babel/core@7.24.4)(@types/react@18.2.22)(immer@9.0.21)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@equinor/eds-core-react': 0.28.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@equinor/eds-core-react': 0.28.0(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@equinor/eds-icons': 0.18.0
       '@equinor/eds-tokens': 0.9.2
       react: 18.2.0
@@ -15248,6 +15213,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@29.5.0(@babel/core@7.24.4):
+    dependencies:
+      '@babel/core': 7.24.4
+      '@jest/transform': 29.5.0
+      '@types/babel__core': 7.20.3
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.5.0(@babel/core@7.24.4)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-merge@3.0.0(@babel/core@7.23.2):
     dependencies:
       '@babel/core': 7.23.2
@@ -15339,11 +15317,33 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.2)
 
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.4):
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.4)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.4)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.4)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.4)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.4)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.4)
+
   babel-preset-jest@29.5.0(@babel/core@7.23.2):
     dependencies:
       '@babel/core': 7.23.2
       babel-plugin-jest-hoist: 29.5.0
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.2)
+
+  babel-preset-jest@29.5.0(@babel/core@7.24.4):
+    dependencies:
+      '@babel/core': 7.24.4
+      babel-plugin-jest-hoist: 29.5.0
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.4)
 
   bail@2.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: 8.3.0
         version: 8.3.0(@types/react@18.2.22)(react@18.2.0)
       '@equinor/workspace-fusion':
-        specifier: 9.0.6-pr.0
-        version: 9.0.6-pr.0(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@babel/core@7.24.4)(@types/react@18.2.22)(@types/sortablejs@1.15.8)(immer@9.0.21)(react-is@18.2.0)
+        specifier: 9.0.6
+        version: 9.0.6(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@babel/core@7.24.4)(@types/react@18.2.22)(@types/sortablejs@1.15.8)(immer@9.0.21)(react-is@18.2.0)
       '@microsoft/applicationinsights-web':
         specifier: ^3.2.0
         version: 3.2.0(tslib@2.6.2)
@@ -2013,8 +2013,8 @@ packages:
       react-is: '>= 16.8.0'
       styled-components: ^5.3.5
 
-  '@equinor/workspace-fusion@9.0.6-pr.0':
-    resolution: {integrity: sha512-GBRGm10J2+nkckyT+z62a5RwfvHJp257Zu750aYqPA8Wpgp07V3AOlFV4nsgy7N/fJjszedcD7hUcBZM8TmfXA==}
+  '@equinor/workspace-fusion@9.0.6':
+    resolution: {integrity: sha512-1L+/zd/Dsxby1sNQRd3VvbHZhpU/X9Kov34pGGuRATJCxM3ShV5kMFZey1aaZn0eBTmRg/FX6gl+xkv5TMJa8A==}
 
   '@equinor/workspace-garden@8.0.1':
     resolution: {integrity: sha512-mDqqJ2SZRPZyvIScc6rqYfmfOxte1tlnPHf8hc2aj4ZUoypg9MSKo0903B04nQi4gT/VOLhDGDsTy5MNFPZ5Pw==}
@@ -2024,8 +2024,8 @@ packages:
       react-is: '>= 16.8.0'
       styled-components: ^5.3.6
 
-  '@equinor/workspace-powerbi@3.0.3-pr.1':
-    resolution: {integrity: sha512-WrUg8bCsc7scJ+jy1EwDRD9AXddT6eF7tIW8gRjMZ4m0Co4h2FD5bL7JP+qUVbCwaK77D4o88vLu7JKb47t4Jg==}
+  '@equinor/workspace-powerbi@3.0.3':
+    resolution: {integrity: sha512-neY2akZsqD8h2hfGQnZTHkkyoPV/aBlRokfGMW32RBCqf3ZMqgbddzuHh4sarfklNNV1EU/z73HQDWAI8gnr9A==}
 
   '@equinor/workspace-react@2.0.1':
     resolution: {integrity: sha512-EMOJU9XL7iVJfMXqcu8d1PjTK6Wblwy2hee9NlS7HNwbhvMy4bvmKV1civu4k5He8bBPfq/9s6XOy0vU63NfLg==}
@@ -10215,7 +10215,7 @@ snapshots:
 
   '@equinor/eds-core-react@0.28.0(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@babel/runtime': 7.24.4
+      '@babel/runtime': 7.23.2
       '@equinor/eds-icons': 0.17.0
       '@equinor/eds-tokens': 0.9.0
       '@equinor/eds-utils': 0.7.0(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -11052,7 +11052,7 @@ snapshots:
       - '@types/sortablejs'
       - supports-color
 
-  '@equinor/workspace-fusion@9.0.6-pr.0(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@babel/core@7.24.4)(@types/react@18.2.22)(@types/sortablejs@1.15.8)(immer@9.0.21)(react-is@18.2.0)':
+  '@equinor/workspace-fusion@9.0.6(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@babel/core@7.24.4)(@types/react@18.2.22)(@types/sortablejs@1.15.8)(immer@9.0.21)(react-is@18.2.0)':
     dependencies:
       '@equinor/eds-core-react': 0.37.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@equinor/eds-icons': 0.21.0
@@ -11060,7 +11060,7 @@ snapshots:
       '@equinor/workspace-ag-grid': 3.0.2(@ag-grid-community/styles@31.2.1)(@ag-grid-enterprise/core@31.2.1)(@types/react@18.2.22)(react-is@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@equinor/workspace-filter': 4.0.3(@babel/core@7.24.4)(@types/sortablejs@1.15.8)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@equinor/workspace-garden': 8.0.1(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
-      '@equinor/workspace-powerbi': 3.0.3-pr.1(@types/sortablejs@1.15.8)
+      '@equinor/workspace-powerbi': 3.0.3(@types/sortablejs@1.15.8)
       '@equinor/workspace-react': 2.0.1(@babel/core@7.24.4)(@types/react@18.2.22)(immer@9.0.21)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@tanstack/react-query': 5.32.0(react@18.2.0)
       re-resizable: 6.9.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -11095,7 +11095,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@equinor/workspace-powerbi@3.0.3-pr.1(@types/sortablejs@1.15.8)':
+  '@equinor/workspace-powerbi@3.0.3(@types/sortablejs@1.15.8)':
     dependencies:
       '@equinor/eds-core-react': 0.37.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@equinor/eds-icons': 0.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,11 +16,11 @@ importers:
         specifier: 31.2.1
         version: 31.2.1
       '@equinor/eds-core-react':
-        specifier: ^0.28.0
-        version: 0.28.0(@babel/core@7.23.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        specifier: ^0.37.0
+        version: 0.37.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@equinor/eds-icons':
-        specifier: 0.19.3
-        version: 0.19.3
+        specifier: 0.21.0
+        version: 0.21.0
       '@equinor/eds-tokens':
         specifier: 0.9.2
         version: 0.9.2


### PR DESCRIPTION
This PR aims to fix all styling errors that occurred after updating dependencies in #982 and #996

Some small attempts were made at fixing some of these issues specifically with eds and styled-components. #1007 & #1011

- [x] Bump eds related packages
- [x] Revert old changes
- [ ] ~Fix remaining styling issues~

Identified issues:
- [ ] PowerBi
    - [ ] QuickFilter popover checkboxes
    - [ ] Quickfilter popover scrollbars
    - [ ] Expanded filter checkboxes
    - [ ] Expanded filter scrollbars
    - [ ] Hide/show filter margin top

Seems like the remaining issues needs to be fixed in equinor/fusion-workspace

Issue: #1014