### PR TITLE
ci: add step summary

### DIFF
--- a/.github/workflows/fprd-deploy.yml
+++ b/.github/workflows/fprd-deploy.yml
@@ -1,4 +1,4 @@
-name: "Deploy PROD build"
+name: 'Deploy PROD build'
 on:
   push:
     branches:
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0 # Required to fetch range
 
       - name: Get fusion token
-        id: "get-fusion-token"
+        id: 'get-fusion-token'
         uses: ./.github/actions/get-fusion-token
         with:
           client-id: ${{secrets.AZURE_PROD_CLIENT_ID}}
@@ -39,9 +39,9 @@ jobs:
         run: |
           echo '# FPRD deployment summary' >> $GITHUB_STEP_SUMMARY
 
-      - name: "Deploy affected apps to Fusion PROD"
+      - name: 'Deploy affected apps to Fusion PROD'
         shell: bash
         env:
           #Runs out of memory when bundling more apps otherwise even though concurrency is 1
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: npx turbo run fprd:deploy --filter=...[HEAD^] --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'

--- a/.github/workflows/fprd-deploy.yml
+++ b/.github/workflows/fprd-deploy.yml
@@ -1,4 +1,4 @@
-name: 'Deploy PROD build'
+name: "Deploy PROD build"
 on:
   push:
     branches:
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0 # Required to fetch range
 
       - name: Get fusion token
-        id: 'get-fusion-token'
+        id: "get-fusion-token"
         uses: ./.github/actions/get-fusion-token
         with:
           client-id: ${{secrets.AZURE_PROD_CLIENT_ID}}
@@ -35,9 +35,13 @@ jobs:
       - name: Build monorepo
         run: pnpm ci:build
 
-      - name: 'Deploy affected apps to Fusion PROD'
+      - name: Start summary
+        run: |
+          echo '# FPRD deployment summary' >> $GITHUB_STEP_SUMMARY
+
+      - name: "Deploy affected apps to Fusion PROD"
         shell: bash
         env:
           #Runs out of memory when bundling more apps otherwise even though concurrency is 1
-          NODE_OPTIONS: '--max_old_space_size=4096'
+          NODE_OPTIONS: "--max_old_space_size=4096"
         run: npx turbo run fprd:deploy --filter=...[HEAD^] --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'

--- a/.github/workflows/manual-deploy-prod.yml
+++ b/.github/workflows/manual-deploy-prod.yml
@@ -17,7 +17,7 @@ on:
           - punch
           - scopechangerequest
           - workorder
-          - '*'
+          - "*"
 permissions:
   actions: read
   checks: write
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0 # Required to fetch range
 
       - name: Get fusion token
-        id: 'get-fusion-token'
+        id: "get-fusion-token"
         uses: ./.github/actions/get-fusion-token
         with:
           client-id: ${{secrets.AZURE_PROD_CLIENT_ID}}
@@ -49,9 +49,13 @@ jobs:
       - name: Build monorepo
         run: npx turbo run build --filter=${{inputs.appKey}}
 
-      - name: 'Deploy affected apps to Fusion FPRD env'
+      - name: Start summary
+        run: |
+          echo '# FPRD deployment summary' >> $GITHUB_STEP_SUMMARY
+
+      - name: "Deploy affected apps to Fusion FPRD env"
         shell: bash
         env:
           #Runs out of memory when bundling more apps otherwise even though concurrency is 1
-          NODE_OPTIONS: '--max_old_space_size=4096'
+          NODE_OPTIONS: "--max_old_space_size=4096"
         run: npx turbo run fprd:deploy --filter=${{inputs.appKey}} --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'

--- a/.github/workflows/manual-deploy-prod.yml
+++ b/.github/workflows/manual-deploy-prod.yml
@@ -17,7 +17,7 @@ on:
           - punch
           - scopechangerequest
           - workorder
-          - "*"
+          - '*'
 permissions:
   actions: read
   checks: write
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0 # Required to fetch range
 
       - name: Get fusion token
-        id: "get-fusion-token"
+        id: 'get-fusion-token'
         uses: ./.github/actions/get-fusion-token
         with:
           client-id: ${{secrets.AZURE_PROD_CLIENT_ID}}
@@ -53,9 +53,9 @@ jobs:
         run: |
           echo '# FPRD deployment summary' >> $GITHUB_STEP_SUMMARY
 
-      - name: "Deploy affected apps to Fusion FPRD env"
+      - name: 'Deploy affected apps to Fusion FPRD env'
         shell: bash
         env:
           #Runs out of memory when bundling more apps otherwise even though concurrency is 1
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: npx turbo run fprd:deploy --filter=${{inputs.appKey}} --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -51,8 +51,8 @@ jobs:
 
       - name: Start summary
         run: |
-          echo "| App          | Files    | Version |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------------|----------|---------|" >> $GITHUB_STEP_SUMMARY
+          echo '| App          | Files    | Version |' >> $GITHUB_STEP_SUMMARY
+          echo '|--------------|----------|---------|' >> $GITHUB_STEP_SUMMARY
 
       - name: "Deploy affected apps to Fusion CI env"
         shell: bash

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -51,8 +51,8 @@ jobs:
 
       - name: Start summary
         run: |
-          echo "| Apps |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------------|" >> $GITHUB_STEP_SUMMARY
+          echo "| App          | Files    | Version |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------------|----------|---------|" >> $GITHUB_STEP_SUMMARY
 
       - name: "Deploy affected apps to Fusion CI env"
         shell: bash

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -51,8 +51,7 @@ jobs:
 
       - name: Start summary
         run: |
-          echo '| App          | Files    | Version |' >> $GITHUB_STEP_SUMMARY
-          echo '|--------------|----------|---------|' >> $GITHUB_STEP_SUMMARY
+          echo '# CI deployment summary' >> $GITHUB_STEP_SUMMARY
 
       - name: "Deploy affected apps to Fusion CI env"
         shell: bash

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -49,24 +49,14 @@ jobs:
       - name: Build monorepo
         run: npx turbo run build --filter='${{inputs.category}}'
 
-      # - name: "Deploy affected apps to Fusion CI env"
-      #   shell: bash
-      #   env:
-      #     #Runs out of memory when bundling more apps otherwise even though concurrency is 1
-      #     NODE_OPTIONS: "--max_old_space_size=4096"
-      #   run: npx turbo run pr:deploy --filter='${{inputs.category}}' --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'
-
-      - name: Generate step summary
+      - name: Start summary
         run: |
-          # Run the build command and capture the output of jq
-          packages_json=$(npx turbo run build --filter='${{ inputs.category }}' --dry-run json --summarize | jq .packages)
-
-          # Start the markdown table with the header
-          echo "| Package Name |" >> $GITHUB_STEP_SUMMARY
+          echo "| Apps |" >> $GITHUB_STEP_SUMMARY
           echo "|--------------|" >> $GITHUB_STEP_SUMMARY
 
-          # Convert JSON array to markdown table rows
-          for package in $(echo "${packages_json}" | jq -r '.[]'); do
-            echo "| ${package} |" >> $GITHUB_STEP_SUMMARY
-          done
+      - name: "Deploy affected apps to Fusion CI env"
         shell: bash
+        env:
+          #Runs out of memory when bundling more apps otherwise even though concurrency is 1
+          NODE_OPTIONS: "--max_old_space_size=4096"
+        run: npx turbo run pr:deploy --filter='${{inputs.category}}' --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -17,7 +17,7 @@ on:
           - punch
           - scopechangerequest
           - workorder
-          - '*'
+          - "*"
 permissions:
   actions: read
   checks: write
@@ -35,8 +35,11 @@ jobs:
         with:
           fetch-depth: 0 # Required to fetch range
 
+      - name: List affected apps
+        run: turbo run build --filter='${{inputs.category}}' --dry-run json --summarize | jq .packages >> $GITHUB_STEP_SUMMARY
+
       - name: Get fusion token
-        id: 'get-fusion-token'
+        id: "get-fusion-token"
         uses: ./.github/actions/get-fusion-token
         with:
           client-id: ${{secrets.AZURE_CLIENT_ID}}
@@ -49,9 +52,9 @@ jobs:
       - name: Build monorepo
         run: npx turbo run build --filter='${{inputs.category}}'
 
-      - name: 'Deploy affected apps to Fusion CI env'
+      - name: "Deploy affected apps to Fusion CI env"
         shell: bash
         env:
           #Runs out of memory when bundling more apps otherwise even though concurrency is 1
-          NODE_OPTIONS: '--max_old_space_size=4096'
+          NODE_OPTIONS: "--max_old_space_size=4096"
         run: npx turbo run pr:deploy --filter='${{inputs.category}}' --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -17,7 +17,7 @@ on:
           - punch
           - scopechangerequest
           - workorder
-          - "*"
+          - '*'
 permissions:
   actions: read
   checks: write
@@ -39,7 +39,7 @@ jobs:
         run: turbo run build --filter='${{inputs.category}}' --dry-run json --summarize | jq .packages >> $GITHUB_STEP_SUMMARY
 
       - name: Get fusion token
-        id: "get-fusion-token"
+        id: 'get-fusion-token'
         uses: ./.github/actions/get-fusion-token
         with:
           client-id: ${{secrets.AZURE_CLIENT_ID}}
@@ -52,9 +52,9 @@ jobs:
       - name: Build monorepo
         run: npx turbo run build --filter='${{inputs.category}}'
 
-      - name: "Deploy affected apps to Fusion CI env"
+      - name: 'Deploy affected apps to Fusion CI env'
         shell: bash
         env:
           #Runs out of memory when bundling more apps otherwise even though concurrency is 1
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: npx turbo run pr:deploy --filter='${{inputs.category}}' --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -17,7 +17,7 @@ on:
           - punch
           - scopechangerequest
           - workorder
-          - '*'
+          - "*"
 permissions:
   actions: read
   checks: write
@@ -35,11 +35,8 @@ jobs:
         with:
           fetch-depth: 0 # Required to fetch range
 
-      - name: List affected apps
-        run: npx turbo run build --filter='${{inputs.category}}' --dry-run json --summarize | jq .packages >> $GITHUB_STEP_SUMMARY
-
       - name: Get fusion token
-        id: 'get-fusion-token'
+        id: "get-fusion-token"
         uses: ./.github/actions/get-fusion-token
         with:
           client-id: ${{secrets.AZURE_CLIENT_ID}}
@@ -52,9 +49,24 @@ jobs:
       - name: Build monorepo
         run: npx turbo run build --filter='${{inputs.category}}'
 
-      - name: 'Deploy affected apps to Fusion CI env'
+      # - name: "Deploy affected apps to Fusion CI env"
+      #   shell: bash
+      #   env:
+      #     #Runs out of memory when bundling more apps otherwise even though concurrency is 1
+      #     NODE_OPTIONS: "--max_old_space_size=4096"
+      #   run: npx turbo run pr:deploy --filter='${{inputs.category}}' --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'
+
+      - name: Generate step summary
+        run: |
+          # Run the build command and capture the output of jq
+          packages_json=$(npx turbo run build --filter='${{ inputs.category }}' --dry-run json --summarize | jq .packages)
+
+          # Start the markdown table with the header
+          echo "| Package Name |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------------|" >> $GITHUB_STEP_SUMMARY
+
+          # Convert JSON array to markdown table rows
+          for package in $(echo "${packages_json}" | jq -r '.[]'); do
+            echo "| ${package} |" >> $GITHUB_STEP_SUMMARY
+          done
         shell: bash
-        env:
-          #Runs out of memory when bundling more apps otherwise even though concurrency is 1
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        run: npx turbo run pr:deploy --filter='${{inputs.category}}' --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -17,7 +17,7 @@ on:
           - punch
           - scopechangerequest
           - workorder
-          - "*"
+          - '*'
 permissions:
   actions: read
   checks: write
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0 # Required to fetch range
 
       - name: Get fusion token
-        id: "get-fusion-token"
+        id: 'get-fusion-token'
         uses: ./.github/actions/get-fusion-token
         with:
           client-id: ${{secrets.AZURE_CLIENT_ID}}
@@ -53,9 +53,9 @@ jobs:
         run: |
           echo '# CI deployment summary' >> $GITHUB_STEP_SUMMARY
 
-      - name: "Deploy affected apps to Fusion CI env"
+      - name: 'Deploy affected apps to Fusion CI env'
         shell: bash
         env:
           #Runs out of memory when bundling more apps otherwise even though concurrency is 1
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: npx turbo run pr:deploy --filter='${{inputs.category}}' --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{github.sha}}'

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0 # Required to fetch range
 
       - name: List affected apps
-        run: turbo run build --filter='${{inputs.category}}' --dry-run json --summarize | jq .packages >> $GITHUB_STEP_SUMMARY
+        run: npx turbo run build --filter='${{inputs.category}}' --dry-run json --summarize | jq .packages >> $GITHUB_STEP_SUMMARY
 
       - name: Get fusion token
         id: 'get-fusion-token'

--- a/github-action/src/releaseMain.ts
+++ b/github-action/src/releaseMain.ts
@@ -9,6 +9,7 @@ import { makeManifest } from './utils/makeManifest.js';
 import { zipBundle } from './utils/zipBundle.js';
 import { uploadBundle } from './utils/uploadBundle.js';
 import { patchAppConfig } from './utils/patchAppConfig.js';
+import { execSync } from 'child_process';
 
 const prodUrl = 'https://fusion-s-portal-fprd.azurewebsites.net';
 
@@ -76,6 +77,8 @@ export async function release(config: ReleaseArgs) {
     pkg.name,
     prodUrl
   );
+
+  execSync(`echo '## ${pkg.name}' >> $GITHUB_STEP_SUMMARY`);
 }
 
 function shouldSkipProd() {

--- a/github-action/src/releasePr.ts
+++ b/github-action/src/releasePr.ts
@@ -48,27 +48,27 @@ program
 await program.parseAsync();
 
 export async function release(context: ReleaseArgs) {
-  // prepareBundle();
-  // makeManifest('./package.json');
-  // const zipped = zipBundle();
+  prepareBundle();
+  makeManifest('./package.json');
+  const zipped = zipBundle();
   const r = parsePackageJson();
   if (!r.name) {
     throw new Error(
       `No name in package json, cannot deploy unknown app at path ${process.cwd()}`
     );
   }
-  // await uploadBundle(ciUrl, context.token, r.name, zipped);
-  // await patchAppConfig(
-  //   {
-  //     ai: context.ai,
-  //     commit: context.sha,
-  //     pr: context.pr,
-  //     modelViewerConfig: JSON.parse(context.modelViewerConfig),
-  //   },
-  //   context.token,
-  //   r.name,
-  //   ciUrl
-  // );
+  await uploadBundle(ciUrl, context.token, r.name, zipped);
+  await patchAppConfig(
+    {
+      ai: context.ai,
+      commit: context.sha,
+      pr: context.pr,
+      modelViewerConfig: JSON.parse(context.modelViewerConfig),
+    },
+    context.token,
+    r.name,
+    ciUrl
+  );
 
   execSync(`echo '## ${r.name}' >> $GITHUB_STEP_SUMMARY`);
 }

--- a/github-action/src/releasePr.ts
+++ b/github-action/src/releasePr.ts
@@ -70,5 +70,5 @@ export async function release(context: ReleaseArgs) {
   //   ciUrl
   // );
 
-  execSync(`echo '| ${r.name} | 2 | ${r.version} |' >> $GITHUB_STEP_SUMMARY`);
+  execSync(`echo '## ${r.name}' >> $GITHUB_STEP_SUMMARY`);
 }

--- a/github-action/src/releasePr.ts
+++ b/github-action/src/releasePr.ts
@@ -70,5 +70,5 @@ export async function release(context: ReleaseArgs) {
   //   ciUrl
   // );
 
-  execSync(`echo "| ${r.name} | 2 | ${r.version} |" >> $GITHUB_STEP_SUMMARY`);
+  execSync(`echo '| ${r.name} | 2 | ${r.version} |' >> $GITHUB_STEP_SUMMARY`);
 }

--- a/github-action/src/releasePr.ts
+++ b/github-action/src/releasePr.ts
@@ -8,6 +8,7 @@ import { makeManifest } from './utils/makeManifest.js';
 import { zipBundle } from './utils/zipBundle.js';
 import { uploadBundle } from './utils/uploadBundle.js';
 import { patchAppConfig } from './utils/patchAppConfig.js';
+import { execSync } from 'child_process';
 
 const ciUrl = 'https://fusion-s-portal-ci.azurewebsites.net';
 
@@ -68,4 +69,6 @@ export async function release(context: ReleaseArgs) {
     r.name,
     ciUrl
   );
+
+  execSync(`echo "| ${r.name} |" >> $GITHUB_STEP_SUMMARY`);
 }

--- a/github-action/src/releasePr.ts
+++ b/github-action/src/releasePr.ts
@@ -48,27 +48,27 @@ program
 await program.parseAsync();
 
 export async function release(context: ReleaseArgs) {
-  prepareBundle();
-  makeManifest('./package.json');
-  const zipped = zipBundle();
+  // prepareBundle();
+  // makeManifest('./package.json');
+  // const zipped = zipBundle();
   const r = parsePackageJson();
   if (!r.name) {
     throw new Error(
       `No name in package json, cannot deploy unknown app at path ${process.cwd()}`
     );
   }
-  await uploadBundle(ciUrl, context.token, r.name, zipped);
-  await patchAppConfig(
-    {
-      ai: context.ai,
-      commit: context.sha,
-      pr: context.pr,
-      modelViewerConfig: JSON.parse(context.modelViewerConfig),
-    },
-    context.token,
-    r.name,
-    ciUrl
-  );
+  // await uploadBundle(ciUrl, context.token, r.name, zipped);
+  // await patchAppConfig(
+  //   {
+  //     ai: context.ai,
+  //     commit: context.sha,
+  //     pr: context.pr,
+  //     modelViewerConfig: JSON.parse(context.modelViewerConfig),
+  //   },
+  //   context.token,
+  //   r.name,
+  //   ciUrl
+  // );
 
-  execSync(`echo "| ${r.name} |" >> $GITHUB_STEP_SUMMARY`);
+  execSync(`echo "| ${r.name} | 2 | ${r.version} |" >> $GITHUB_STEP_SUMMARY`);
 }


### PR DESCRIPTION
## Motivation
Today it is hard to see for a given pr/prod deployment which apps were actually deployed. You would have to scroll through all the workflow step logs to see. With this PR every workflow will have a markdown output listing all the deployed apps


It would be nice to see it in the PR conversation tab but its probably not that easy because the deployment relies on a branch which is not necessarily a PR


The changes can be viewed in [dev](https://jc.fusion.dev.equinor.com)
