### PR TITLE
fix(sidesheet table): loading and no data showing simultaneously

### DIFF
--- a/libs/shared/src/packages/table-helpers/src/lib/table/TabTable/TabTable.tsx
+++ b/libs/shared/src/packages/table-helpers/src/lib/table/TabTable/TabTable.tsx
@@ -55,7 +55,7 @@ export const TabTable = <T extends Record<PropertyKey, unknown>>(
         </NoResourceData>
       )}
 
-      {packages && packages.length === 0 && (
+      {!isFetching && packages && packages.length === 0 && (
         <NoResourceData>
           <Icon
             name="info_circle"


### PR DESCRIPTION
Fixed a bug introduced in  d7c6d19
I am not 100% sure how to repro but it was showing `fetching` and `no data` at the same time