### PR TITLE
fix: add error handling for version retrieval in bumpVersion utility

### DIFF
--- a/github-action/src/utils/bumpVersion.ts
+++ b/github-action/src/utils/bumpVersion.ts
@@ -4,13 +4,20 @@ import { HttpClient } from '@actions/http-client';
 // For now we ask the server what the latest version is and bump the patch version
 export async function getVersion(ciUrl: string, token: string, name: string) {
   const client = new HttpClient();
-  const response = await client.get(`${ciUrl}/apps/${name}?api-version=1.0`, {
-    ['Authorization']: `Bearer ${token}`,
-  });
-  const body = await response.readBody();
-  const json = JSON.parse(body);
-  const v = incrementPatchVersion(json.build.version);
-  return v;
+  try {
+    const response = await client.get(`${ciUrl}/apps/${name}?api-version=1.0`, {
+      ['Authorization']: `Bearer ${token}`,
+    });
+    const body = await response.readBody();
+    const json = JSON.parse(body);
+    const v = incrementPatchVersion(json.build.version);
+    return v;
+
+  } catch (error) {
+    console.warn("Failed to get version from server", error);
+    console.info("Falling back to 0.0.1");
+    return "0.0.1";
+  }
 }
 
 function incrementPatchVersion(semver: string) {


### PR DESCRIPTION
### Short summary
add error handling for version retrieval in bumpVersion utility
Link to issue: #1186 

### PR Checklist
- [x] I have performed a self-review of my own code
- [x] I have written a short summary of my changes in the PR
- [x] I have linked related issue to the PR

> [!TIP]
> To deploy the PR to Test, use the [Manual deploy fusion app TEST🚀](https://github.com/equinor/cc-components/actions/workflows/manual-deploy.yml) action.
> Remember to deploy any backend changes to Test as well!

> [!CAUTION]
> ⛔ I understand by merging my PR, the changes will be deployed to production immediately ⛔