### PR TITLE
Potential fix for code scanning alert no. 7: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         if: success()
         with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          ref: ${{ steps.comment-branch.outputs.head_sha }}
           fetch-depth: 0
 
       - name: Get fusion token


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/cc-components/security/code-scanning/7](https://github.com/equinor/cc-components/security/code-scanning/7)

To fix the issue, we need to ensure that the workflow checks out code using an immutable reference, such as the commit SHA, instead of the mutable branch reference (`head_ref`). This can be achieved by replacing `${{ steps.comment-branch.outputs.head_ref }}` with `${{ steps.comment-branch.outputs.head_sha }}` in the `actions/checkout@v4` step. This change ensures that the workflow always checks out the exact commit that was referenced when the workflow was triggered, preventing any TOCTOU vulnerabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
