### PR TITLE
Read color assist mode to handover

### DIFF
--- a/libs/handoverapp/src/lib/ui-garden/Item.tsx
+++ b/libs/handoverapp/src/lib/ui-garden/Item.tsx
@@ -1,5 +1,6 @@
 import { HandoverPackage } from '@cc-components/handovershared';
 import { FlagIcon, PopoverWrapper, WarningIcon } from '@cc-components/shared/common';
+import { getStatusCircle } from '@cc-components/shared';
 import { CustomItemView } from '@equinor/workspace-fusion/garden';
 import { memo, useMemo, useRef, useState } from 'react';
 import { getDotsColor, getItemSize, getTextColor } from '../utils-garden';
@@ -10,7 +11,6 @@ import {
   StyledItemWrapper,
   StyledRoot,
   StyledSizes,
-  StyledStatusCircles,
   StyledWarningIconWrapper,
 } from './garden.styles';
 import { PopoverContent } from './PopoverContent';
@@ -33,6 +33,7 @@ const HandoverItem = (args: CustomItemView<HandoverPackage>) => {
     rowStart,
     columnStart,
     parentRef,
+    colorAssistMode,
   } = args;
 
   const size = getItemSize(data.volume, 100);
@@ -57,6 +58,13 @@ const HandoverItem = (args: CustomItemView<HandoverPackage>) => {
 
   const mcPackageColor = getDotsColor(data.mechanicalCompletionStatus);
   const commStatusColor = getDotsColor(data.status);
+
+  const mcStatusCircle = getStatusCircle(
+    data.mechanicalCompletionStatus,
+    colorAssistMode
+  );
+
+  const commStatusCircle = getStatusCircle(data.status, colorAssistMode);
 
   const showWarningIcon =
     data.mechanicalCompletionStatus === 'OS' &&
@@ -117,7 +125,12 @@ const HandoverItem = (args: CustomItemView<HandoverPackage>) => {
               <WarningIcon />
             </StyledWarningIconWrapper>
           )}
-          <StyledStatusCircles mcColor={mcPackageColor} commColor={commStatusColor} />
+          <div
+            style={{ display: 'flex', gap: '4px', height: '14px', marginLeft: 'auto' }}
+          >
+            {mcStatusCircle}
+            {commStatusCircle}
+          </div>
         </StyledItemWrapper>
 
         {columnExpanded && (

--- a/libs/handoverapp/src/lib/ui-garden/garden.styles.ts
+++ b/libs/handoverapp/src/lib/ui-garden/garden.styles.ts
@@ -66,31 +66,7 @@ type StatusCirclesProps = {
   mcColor: string;
   commColor: string;
 };
-export const StyledStatusCircles = styled.div<StatusCirclesProps>`
-  display: flex;
-  grid-column: 4;
-  justify-content: end;
-  align-items: center;
 
-  &:before {
-    width: 12px;
-    height: 12px;
-    border: 1px solid white;
-    background-color: ${(props) => props.mcColor};
-    border-radius: 50%;
-    margin: 0px 1px;
-    content: ' ';
-  }
-  &:after {
-    width: 12px;
-    height: 12px;
-    border: 1px solid white;
-    background-color: ${(props) => props.commColor};
-    border-radius: 50%;
-    margin: 0px 1px;
-    content: ' ';
-  }
-`;
 export const StyledWarningIconWrapper = styled.div`
   position: absolute;
   top: 3px;


### PR DESCRIPTION
### Short summary
Readds handover status colors checking the correct property

### Link to issue:
CLOSES https://github.com/equinor/cc-toolbox/issues/2524

### PR Checklist
- [x] I have performed a self-review of my own code
- [x] I have written a short summary of my changes in the PR
- [ ] I have linked related issue to the PR

> [!TIP]
> To deploy the PR to Test, use the [Manual deploy fusion app TEST🚀](https://github.com/equinor/cc-components/actions/workflows/manual-deploy.yml) action.
> Remember to deploy any backend changes to Test as well!

> [!CAUTION]
> ⛔ I understand by merging my PR, the changes will be deployed to production immediately ⛔