### PR TITLE
fix: Garden popover location is now relatative to the hovered element

### DIFF
--- a/libs/handoverapp/src/lib/ui-garden/Item.tsx
+++ b/libs/handoverapp/src/lib/ui-garden/Item.tsx
@@ -28,10 +28,7 @@ const HandoverItem = (args: CustomItemView<HandoverPackage>) => {
     onClick,
     columnExpanded,
     width: itemWidth = 300,
-    depth,
     isSelected,
-    rowStart,
-    columnStart,
     parentRef,
     colorAssistMode,
   } = args;
@@ -70,7 +67,6 @@ const HandoverItem = (args: CustomItemView<HandoverPackage>) => {
     data.mechanicalCompletionStatus === 'OS' &&
     data.commissioningPackageStatus === 'RFC Accepted';
 
-  const width = useMemo(() => (depth ? 100 - depth * 3 : 100), [depth]);
   const fittedWidth = useMemo(() => itemWidth * 0.98, [itemWidth]);
 
   const options: ItemOptions = {
@@ -102,6 +98,7 @@ const HandoverItem = (args: CustomItemView<HandoverPackage>) => {
     // Close the popover immediately
     setIsOpen(false);
   };
+
   return (
     <>
       <StyledRoot>
@@ -144,11 +141,10 @@ const HandoverItem = (args: CustomItemView<HandoverPackage>) => {
         <PopoverWrapper
           close={() => setIsOpen(false)}
           isOpen={isOpen}
-          rowStart={rowStart}
-          columnStart={columnStart}
           width={itemWidth}
           parentRef={parentRef}
           popoverTitle={`Comm.pkg ${data.commissioningPackageNo}`}
+          anchorRef={anchorRef}
         >
           <PopoverContent data={data} itemOptions={options} />
         </PopoverWrapper>

--- a/libs/heattraceapp/src/lib/ui-garden/Item.tsx
+++ b/libs/heattraceapp/src/lib/ui-garden/Item.tsx
@@ -1,9 +1,5 @@
 import { colorMap } from '@cc-components/shared/mapping';
-import {
-  PackageStatus,
-  PopoverWrapper,
-  getStatusCircle,
-} from '@cc-components/shared';
+import { PackageStatus, PopoverWrapper, getStatusCircle } from '@cc-components/shared';
 import { CustomItemView } from '@equinor/workspace-fusion/garden';
 import { memo, useMemo, useRef, useState } from 'react';
 import {
@@ -30,8 +26,6 @@ const HeattraceGardenItem = (props: CustomItemView<HeatTrace>) => {
     depth,
     width: itemWidth = 300,
     isSelected,
-    rowStart,
-    columnStart,
     parentRef,
     displayName,
     colorAssistMode,
@@ -44,8 +38,6 @@ const HeattraceGardenItem = (props: CustomItemView<HeatTrace>) => {
   } = useMemo(() => getHeatTraceStatuses(data), [data]);
   const width = useMemo(() => (depth ? 100 - depth * 3 : 100), [depth]);
   const maxWidth = useMemo(() => itemWidth * 0.98, [itemWidth]);
-
-
 
   const mcStatus = getStatusCircle(data.mechanicalCompletionStatus, colorAssistMode);
   const comStatus = getStatusCircle(data.commissioningStatus, colorAssistMode);
@@ -88,12 +80,11 @@ const HeattraceGardenItem = (props: CustomItemView<HeatTrace>) => {
       {isOpen && (
         <PopoverWrapper
           isOpen={isOpen}
-          rowStart={rowStart}
-          columnStart={columnStart}
           width={itemWidth}
           parentRef={parentRef}
           popoverTitle={`${data.heatTraceCableDescription}`}
           close={() => setIsOpen(false)}
+          anchorRef={anchorRef}
         />
       )}
     </>

--- a/libs/loopapp/src/lib/ui-garden/Item.tsx
+++ b/libs/loopapp/src/lib/ui-garden/Item.tsx
@@ -1,7 +1,5 @@
 import { Loop } from '@cc-components/loopshared';
-import {
-  PopoverWrapper,
-} from '@cc-components/shared/common';
+import { PopoverWrapper } from '@cc-components/shared/common';
 import { getStatusCircle } from '@cc-components/shared';
 import { statusColorMap } from '@cc-components/shared/mapping';
 import { CustomItemView } from '@equinor/workspace-fusion/garden';
@@ -33,8 +31,6 @@ const LoopGardenItem = (props: CustomItemView<Loop>) => {
     depth,
     width: itemWidth = 300,
     isSelected,
-    rowStart,
-    columnStart,
     parentRef,
     displayName,
     colorAssistMode,
@@ -87,11 +83,10 @@ const LoopGardenItem = (props: CustomItemView<Loop>) => {
         <PopoverWrapper
           close={() => setIsOpen(false)}
           isOpen={isOpen}
-          rowStart={rowStart}
-          columnStart={columnStart}
           width={itemWidth}
           parentRef={parentRef}
           popoverTitle={`${data.loopNo}`}
+          anchorRef={anchorRef}
         >
           <PopoverContent loop={data} />
         </PopoverWrapper>

--- a/libs/mechanicalcompletionapp/src/lib/ui-garden/Item.tsx
+++ b/libs/mechanicalcompletionapp/src/lib/ui-garden/Item.tsx
@@ -1,6 +1,4 @@
-import {
-  PopoverWrapper,
-} from '@cc-components/shared/common';
+import { PopoverWrapper } from '@cc-components/shared/common';
 import { getStatusCircle } from '@cc-components/shared';
 import { statusColorMap } from '@cc-components/shared/mapping';
 import { CustomItemView } from '@equinor/workspace-fusion/garden';
@@ -33,6 +31,7 @@ const McGardenItem = (props: CustomItemView<McPackage>) => {
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
 
   const size = getTagSize(data, 10);
   const status = data.commissioningStatus;
@@ -87,6 +86,7 @@ const McGardenItem = (props: CustomItemView<McPackage>) => {
           textColor={contentsColor}
           isSelected={isSelected}
           style={{ width: `${columnExpanded ? 100 : width}%`, maxWidth }}
+          ref={anchorRef}
         >
           <StyledSizes color={contentsColor} size={size} />
           <StyledItemText> {data.mechanicalCompletionPackageNo}</StyledItemText>
@@ -110,9 +110,8 @@ const McGardenItem = (props: CustomItemView<McPackage>) => {
           isOpen={isOpen}
           width={itemWidth}
           parentRef={parentRef}
-          rowStart={rowStart}
-          columnStart={columnStart}
           popoverTitle={`Mc.pkg: ${data.mechanicalCompletionPackageNo}`}
+          anchorRef={anchorRef}
         >
           <PopoverContent data={data} options={options} />
         </PopoverWrapper>

--- a/libs/pipingapp/src/lib/ui-garden/Item.tsx
+++ b/libs/pipingapp/src/lib/ui-garden/Item.tsx
@@ -9,11 +9,7 @@ import {
   StyledStatusCircles,
 } from './garden.styles';
 import { Pipetest } from 'libs/pipingshared/dist/src';
-import {
-  PackageStatus,
-  PopoverWrapper,
-  getStatusCircle,
-} from '@cc-components/shared';
+import { PackageStatus, PopoverWrapper, getStatusCircle } from '@cc-components/shared';
 import { getPipetestStatusColors } from '../utils-garden/getPipetestStatusColors';
 import { itemContentColors } from '@cc-components/shared/mapping';
 
@@ -82,12 +78,11 @@ const PipetestGardenItem = (props: CustomItemView<Pipetest>) => {
       {isOpen && (
         <PopoverWrapper
           isOpen={isOpen}
-          rowStart={rowStart}
-          columnStart={columnStart}
           width={itemWidth}
           parentRef={parentRef}
           popoverTitle={data.description}
           close={() => setIsOpen(false)}
+          anchorRef={anchorRef}
         />
       )}
     </>

--- a/libs/shared/src/packages/common/src/lib/popover/PopoverWrapper.tsx
+++ b/libs/shared/src/packages/common/src/lib/popover/PopoverWrapper.tsx
@@ -1,13 +1,6 @@
 import { Icon, Popover, Typography } from '@equinor/eds-core-react';
 import { tokens } from '@equinor/eds-tokens';
-import {
-  MutableRefObject,
-  PropsWithChildren,
-  ReactElement,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { MutableRefObject, PropsWithChildren, ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 
@@ -20,12 +13,11 @@ const StyledPopover = styled(Popover)`
 
 type PopoverWrapperProps = {
   isOpen: boolean;
-  rowStart: number;
-  columnStart: number;
   width: number;
   popoverTitle: string;
   parentRef: MutableRefObject<HTMLDivElement | null>;
   close: VoidFunction;
+  anchorRef: MutableRefObject<HTMLDivElement | null>;
 };
 
 /**
@@ -34,70 +26,35 @@ type PopoverWrapperProps = {
  */
 export const PopoverWrapper = ({
   isOpen,
-  rowStart,
-  columnStart,
   width,
   parentRef,
   popoverTitle,
   children,
   close,
+  anchorRef,
 }: PropsWithChildren<PopoverWrapperProps>): ReactElement | null => {
-  const [placement, setPlacement] = useState<{ x: number; y: number }>({
-    y: 30,
-    x: -width / 2,
-  });
-  const ref = useRef<HTMLDivElement | null>(null);
-
-  useLayoutEffect(() => {
-    if (ref && ref.current && isOpen) {
-      const clientRect = ref.current.getBoundingClientRect();
-      // If Popover is out of bounds right side
-      if (clientRect.right > window.innerWidth) {
-        setPlacement((s) => ({ x: -clientRect.width, y: s.y }));
-      }
-
-      // If popover is out of bounds left side
-      if (clientRect.left < 0) {
-        setPlacement((s) => ({ x: width, y: s.y }));
-      }
-
-      // If popover is out of bounds bottom
-      if (clientRect.bottom > window.innerHeight) {
-        setPlacement((s) => ({ x: s.x, y: -clientRect.height }));
-      }
-    }
-  }, [isOpen, width]);
-
   if (!isOpen || !parentRef.current) return null;
 
   return createPortal(
-    <div
-      style={{
-        position: 'absolute',
-        top: `${rowStart + placement.y}px`,
-        left: `${columnStart + placement.x}px`,
-      }}
-    >
-      <StyledPopover open={isOpen} ref={ref}>
-        <Popover.Title
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            margin: '0px 14px',
-          }}
-        >
-          <Typography as={'h2'}>{popoverTitle}</Typography>
-          <Icon
-            name="close"
-            onClick={() => close()}
-            color={tokens.colors.interactive.primary__resting.hex}
-          />
-        </Popover.Title>
+    <StyledPopover open={isOpen} anchorEl={anchorRef.current}>
+      <Popover.Title
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          margin: '0px 14px',
+        }}
+      >
+        <Typography as={'h2'}>{popoverTitle}</Typography>
+        <Icon
+          name="close"
+          onClick={() => close()}
+          color={tokens.colors.interactive.primary__resting.hex}
+        />
+      </Popover.Title>
 
-        <Popover.Content>{children}</Popover.Content>
-      </StyledPopover>
-    </div>,
+      <Popover.Content>{children}</Popover.Content>
+    </StyledPopover>,
     parentRef.current
   );
 };

--- a/libs/workorderapp/src/lib/ui-garden/Item.tsx
+++ b/libs/workorderapp/src/lib/ui-garden/Item.tsx
@@ -98,10 +98,9 @@ const WorkorderItem = (props: CustomItemView<WorkOrder>): ReactElement => {
           close={() => setIsOpen(false)}
           popoverTitle={`Wo.Number: ${data.workOrderNumber}`}
           width={itemWidth}
-          columnStart={columnStart}
           parentRef={parentRef}
-          rowStart={rowStart}
           isOpen={isOpen}
+          anchorRef={anchorRef}
         >
           <WorkOrderPopover
             data={data}


### PR DESCRIPTION
### Short summary
Fixes an issue where the popover was always in the top left corner when a garden element is hovered

Link to issue:
https://github.com/equinor/cc-components/issues/1262

### PR Checklist
- [x] I have performed a self-review of my own code
- [x] I have written a short summary of my changes in the PR
- [x] I have linked related issue to the PR

> [!TIP]
> To deploy the PR to Test, use the [Manual deploy fusion app TEST🚀](https://github.com/equinor/cc-components/actions/workflows/manual-deploy.yml) action.
> Remember to deploy any backend changes to Test as well!

> [!CAUTION]
> ⛔ I understand by merging my PR, the changes will be deployed to production immediately ⛔