### PR TITLE
Potential fix for code scanning alert no. 7: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         if: success()
         with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          ref: ${{ steps.comment-branch.outputs.head_sha }}
           fetch-depth: 0
 
       - name: Get fusion token


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/cc-components/security/code-scanning/7](https://github.com/equinor/cc-components/security/code-scanning/7)

To fix the problem, we must change the workflow to check out code using an *immutable* reference—the commit SHA corresponding to the PR branch at comment-trigger time—instead of a mutable branch ref. This ensures that after the check (the PR comment and any approvals of the workflow) the code being built cannot be changed by a subsequent force-push. Specifically, replace `ref: ${{ steps.comment-branch.outputs.head_ref }}` with `ref: ${{ steps.comment-branch.outputs.head_sha }}` in the `actions/checkout` step. This change is fully compatible and preserves existing functionality, as the commit SHA for the PR branch is already obtained via the `pull-request-comment-branch` action. The edit is limited to the `actions/checkout` step in `.github/workflows/pr-deploy.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
