### PR TITLE
Potential fix for code scanning alert no. 6: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         if: success()
         with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          ref: ${{ steps.comment-branch.outputs.head_sha }}
           fetch-depth: 0
 
       - name: Get fusion token


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/cc-components/security/code-scanning/6](https://github.com/equinor/cc-components/security/code-scanning/6)

To fully address the problem, ensure the workflow checks out code using an immutable reference, namely the commit SHA associated with the PR branch when the comment triggers the workflow. The best way is to change `ref: ${{ steps.comment-branch.outputs.head_ref }}` in the `actions/checkout` step to use the SHA value that is also provided by the `pull-request-comment-branch` action as an output (commonly `head_sha`). This ensures the code being built and deployed cannot be altered after the approval or gating step, protecting all subsequent privileged actions. Edit lines 28 in `.github/workflows/pr-deploy.yml` as follows:

- Replace `ref: ${{ steps.comment-branch.outputs.head_ref }}` with `ref: ${{ steps.comment-branch.outputs.head_sha }}`.

No other imports, definitions, or files need to be changed unless subsequent steps also reference the mutable branch; in this snippet, deployment step already uses the SHA, so further changes aren't necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
