### PR TITLE
fix: resolve code scanning security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -1,7 +1,7 @@
 name: 'Deploy PR build'
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [labeled]
 
 permissions:
   actions: read
@@ -12,21 +12,18 @@ permissions:
   deployments: write
   id-token: write
   statuses: write
+
 jobs:
   deploy-affected-ci:
-    # only run if pull request is approved and QA is required
-    if: contains(github.event.comment.body, 'deploy test')
+    if: github.event.label.name == 'deploy-test'
     runs-on: ubuntu-latest
     environment: ci
     steps:
-      - uses: xt0rted/pull-request-comment-branch@v2
-        id: comment-branch
-
       - uses: actions/checkout@v4
-        if: success()
         with:
-          ref: ${{ steps.comment-branch.outputs.head_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get fusion token
         id: 'get-fusion-token'
@@ -45,12 +42,11 @@ jobs:
       - name: 'Deploy affected apps to Fusion CI'
         shell: bash
         env:
-          #Runs out of memory when bundling more apps otherwise even though concurrency is 1
           NODE_OPTIONS: '--max_old_space_size=4096'
           GITHUB_STEP_SUMMARY: $GITHUB_STEP_SUMMARY
-        run: npx turbo run pr:deploy --since origin/main --scope * --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --pr '${{ github.event.issue.number }}' --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{steps.comment-branch.outputs.head_sha}}'
+        run: npx turbo run pr:deploy --since origin/main --scope * --concurrency 1 -- --token ${{ steps.get-fusion-token.outputs.token }} --pr '${{ github.event.pull_request.number }}' --ai '${{secrets.ai}}' --modelViewerConfig '${{vars.modelViewerConfig}}' --sha '${{ github.event.pull_request.head.sha }}'
 
-      - name: Comment pr
+      - name: Comment PR
         uses: actions/github-script@v7
         with:
           script: |
@@ -60,3 +56,19 @@ jobs:
               repo: context.repo.repo,
               body: 'Deployed! 🚀'
             })
+
+      - name: Remove deploy label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'deploy-test'
+              });
+            } catch (e) {
+              core.info('Label already removed or not found');
+            }

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -4,6 +4,9 @@ run-name: ${{ github.actor }} is scanning for secrets
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   TruffleHog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes 5 GitHub code scanning alerts:

### Missing Permissions (Alerts #1, #2, #8)
- **ci.yml** — Added `permissions: contents: read`
- **post-pr.yml** — Added `permissions: {}` (only needs webhook secret, no GITHUB_TOKEN scopes)
- **trufflehog.yml** — Added `permissions: contents: read`

### Untrusted Checkout TOCTOU (Alerts #4, #5 — Critical)
- **pr-deploy.yml** — Replaced `issue_comment` trigger with `pull_request: [labeled]`

The `issue_comment` trigger had a Time-of-Check to Time-of-Use (TOCTOU) vulnerability: the PR HEAD was resolved dynamically via API (`xt0rted/pull-request-comment-branch`), leaving a window where a force-push could substitute malicious code before checkout.

The new approach:
- Uses `pull_request: types: [labeled]` with a `deploy-test` label
- Checks out at `github.event.pull_request.head.sha` (immutable, set at event creation)
- Adds `persist-credentials: false` for defense-in-depth
- Auto-removes the label after the workflow completes
- Only users with write access can add labels (vs any commenter triggering via `issue_comment`)

### Migration
Instead of commenting `deploy test` on a PR, add the `deploy-test` label to trigger a test deployment.

Resolves:
- https://github.com/equinor/cc-components/security/code-scanning/1
- https://github.com/equinor/cc-components/security/code-scanning/2
- https://github.com/equinor/cc-components/security/code-scanning/4
- https://github.com/equinor/cc-components/security/code-scanning/5
- https://github.com/equinor/cc-components/security/code-scanning/8