### PR TITLE
feat: set fusion app owners from env config

### DIFF
--- a/.github/workflows/create-fusion-app.yml
+++ b/.github/workflows/create-fusion-app.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: 'Create application in Fusion CI'
         shell: bash
-        run: npx tsx ./github-action/src/createFusionApp.ts create -T ${{ steps.get-fusion-token-ci.outputs.token }} -A '${{inputs.appKey}}' -C '${{inputs.category}}' -D '${{inputs.displayName}}' -O '${{vars.FUSION_APP_ADMINS_CI}}' -E 'CI'
+        run: npx tsx ./github-action/src/createFusionApp.ts create -T ${{ steps.get-fusion-token-ci.outputs.token }} -A '${{inputs.appKey}}' -C '${{inputs.category}}' -D '${{inputs.displayName}}' -O '${{vars.FUSION_APP_ADMINS_CI}}' -W '${{vars.FUSION_APP_OWNERS_CI}}' -E 'CI'
 
   create-fusion-app-fprd:
     runs-on: ubuntu-latest
@@ -95,4 +95,4 @@ jobs:
 
       - name: 'Create application in Fusion FPRD'
         shell: bash
-        run: npx tsx ./github-action/src/createFusionApp.ts create -T ${{ steps.get-fusion-token-fprd.outputs.token }} -A '${{inputs.appKey}}' -C '${{inputs.category}}' -D '${{inputs.displayName}}' -O '${{vars.FUSION_APP_ADMINS_FPRD}}'  -E 'FPRD'
+        run: npx tsx ./github-action/src/createFusionApp.ts create -T ${{ steps.get-fusion-token-fprd.outputs.token }} -A '${{inputs.appKey}}' -C '${{inputs.category}}' -D '${{inputs.displayName}}' -O '${{vars.FUSION_APP_ADMINS_FPRD}}' -W '${{vars.FUSION_APP_OWNERS_FPRD}}' -E 'FPRD'

--- a/github-action/src/createFusionApp.ts
+++ b/github-action/src/createFusionApp.ts
@@ -44,6 +44,7 @@ program
   .option('-D, --displayname <displayname>')
   .option('-C, --category <category>')
   .option('-O, --admins <admins>')
+  .option('-W, --owners <owners>')
   .option('-E, env <env>')
   .action(async (args) => {
     const fusionEnv: string = args.env;
@@ -69,6 +70,9 @@ program
       throw new Error('Application needs atleast one admin');
     }
 
+    const owners =
+      args.owners && args.owners.trim().length > 0 ? args.owners.split(',') : [];
+
     setSecret(args.token);
     createFusionApp(
       args.token,
@@ -76,6 +80,7 @@ program
       args.displayname,
       args.category,
       admins,
+      owners,
       fusionEnv as 'CI' | 'FPRD'
     );
   });
@@ -102,6 +107,7 @@ export async function createFusionApp(
   displayName: string,
   categoryName: string,
   admins: string[],
+  owners: string[],
   env: 'CI' | 'FPRD'
 ) {
   //TODO: fetch dynamically
@@ -118,7 +124,7 @@ export async function createFusionApp(
     name: displayName,
     shortName: appKey,
     description: '.',
-    owners: [],
+    owners,
     admins: admins.map((s) => ({ azureUniqueId: s })),
     accentColor: category.color,
     categoryId: category.id,

--- a/github-action/src/createFusionApp.ts
+++ b/github-action/src/createFusionApp.ts
@@ -12,7 +12,7 @@ type FusionApp = {
   name: string;
   shortName: string;
   description: string;
-  owners: string[];
+  owners: { azureUniqueId: string }[];
   admins: { azureUniqueId: string }[];
   accentColor: string;
   categoryId: string;
@@ -124,7 +124,7 @@ export async function createFusionApp(
     name: displayName,
     shortName: appKey,
     description: '.',
-    owners,
+    owners: owners.map((s) => ({ azureUniqueId: s })),
     admins: admins.map((s) => ({ azureUniqueId: s })),
     accentColor: category.color,
     categoryId: category.id,


### PR DESCRIPTION
## What
Adds optional **owners** support when creating a Fusion app, sourced from GitHub environment variables, mirroring how admins are already configured.

## Changes
- createFusionApp.ts: new `-W, --owners` option (comma-separated Azure object IDs), parsed to an array (defaults to `[]` when unset) and included in the `/api/apps` payload instead of a hardcoded empty array.
- create-fusion-app.yml: CI and FPRD jobs pass owners via `-W '${{ vars.FUSION_APP_OWNERS_CI }}'` / `FUSION_APP_OWNERS_FPRD`.

## Config
The env variables `FUSION_APP_OWNERS_CI` and `FUSION_APP_OWNERS_FPRD` have been set in the `ci` and `fprd` environments with the team's object IDs.

## Notes
Owners are sent as a plain string array (matching the `owners: string[]` type); admins remain wrapped as `{ azureUniqueId }`.