### PR TITLE
docs: add knowledge base for CC reports and ADS Power BI embedding

### DIFF
--- a/.github/knowledge/README.md
+++ b/.github/knowledge/README.md
@@ -1,0 +1,33 @@
+# Knowledge Base
+
+Structured mental-model notes for `equinor/cc-components`, seeded while investigating
+[cc-toolbox#4792](https://github.com/equinor/cc-toolbox/issues/4792) (interaction tracking in
+embedded ADS Power BI reports).
+
+These files capture **how subsystems connect, why they're designed that way, and the invariants
+that must hold** — not step-by-step how-tos (those belong in `.github/skills/`).
+
+## Notation
+
+Each entry uses the knowledge-builder structured notation:
+
+- **OWNS** — what this unit is the source of truth for
+- **READS FROM** — its inputs / upstream dependencies
+- **WRITES TO** — its outputs / downstream effects
+- **INVARIANT** — a rule that must always hold
+- **FLOW** — an end-to-end operation trace
+- **TENSION** — a known pressure point or trade-off
+- **DECIDED** — a deliberate design decision and its rationale
+
+## Index
+
+| File | Scope |
+|------|-------|
+| [reports-architecture.md](reports-architecture.md) | CC reports (`reports/*`) and the `@cc-components/reportshared` runtime |
+| [power-bi-embedding.md](power-bi-embedding.md) | The embed pipeline across `reportshared` → `workspace-fusion` → `workspace-powerbi` → `PowerBIEmbed` |
+| [domains/ads-reports.md](domains/ads-reports.md) | The ADS report set and the cc-toolbox#4792 tracking feature |
+
+## Maintaining
+
+Follow `.github/skills/knowledge-builder/SKILL.md` after any non-trivial task: reflect, classify
+(code comment vs. knowledge vs. instruction vs. skill), and update in the same change.

--- a/.github/knowledge/domains/ads-reports.md
+++ b/.github/knowledge/domains/ads-reports.md
@@ -1,0 +1,55 @@
+---
+domain: ads-reports
+related: [reports-architecture, power-bi-embedding]
+---
+
+# ADS Reports — Domain Knowledge
+
+The **ADS** reports are a subset of CC reports under `reports/ads-*` (the `ads-` prefix; the
+"ADS" label is used by the business — expansion not asserted here). They embed Power BI reports
+scoped to a **ProjectMaster** context and are the subject of `equinor/cc-toolbox#4792` (enable
+user-interaction tracking in the embedded reports).
+
+## ads-report-set
+
+- OWNS: the ADS report app shells under `reports/`
+- INVARIANT: all ADS reports call `configure(['ProjectMaster'])` — ProjectMaster context only (unlike most other reports which also allow `Facility`)
+- INVARIANT: the members and their `reportId`s are:
+  - `ads-schedule-viewer` → `ads-schedule-viewer`
+  - `ads-weekly-meeting` → `ads-weekly-meeting`
+  - `ads-monthly-meeting` → `ads-monthly-meeting`
+  - `ads-commercial-meeting` → `ads-commercial-meeting`
+  - `ads-engineering-meeting` → `ads-engineering-meeting`
+  - `ads-offshore-installation` → `ads-offshore-installation-trends` (folder name ≠ reportId)
+- INVARIANT: each shell is identical except `reportId`; they share the entire runtime from `@cc-components/reportshared` (see `reports-architecture.md`)
+
+## ads-context-scoping
+
+- OWNS: how an ADS report is filtered to the selected project
+- READS FROM: `currentContext.type.id === 'ProjectMaster'` → `pbi_context_mapping.ProjectMaster` = `{ table: 'Dim_ProjectMaster', column: 'ProjectMaster GUID' }`
+- WRITES FROM: a Power BI `IBasicFilter` with `values: [context.externalId]` applied to the embedded report
+- INVARIANT: the report will not render without a ProjectMaster context selected (guarded by `RootAppWrapper`)
+
+## ads-interaction-tracking (cc-toolbox#4792)
+
+- OWNS: the feature to track user interactions in embedded ADS Power BI reports
+- DECIDED: implement by threading a `useTrackFeature`-backed `eventHandlers` map from `reportshared`
+  down to `<PowerBIEmbed>` (full mechanism documented in `power-bi-embedding.md` → `interaction-tracking`)
+- INVARIANT: reuse `fusion-core-apps/apps/pbi-template` event names and payloads verbatim for cross-app
+  consistency — `fusion-pbi:${event}` where event ∈ `{loaded, rendered, error, buttonClicked, pageChanged, dataSelected}`
+- INVARIANT: scope is **ADS reports only** (confirmed with requester) — the threading approach naturally
+  limits tracking to reports because only `reportshared` supplies the handler map; `apps/*` workspace
+  Power BI tabs are unaffected
+- TENSION: verification requires the Fusion portal's `analytics` provider at runtime; `useTrackFeature`
+  silently no-ops (emits a telemetry exception) if absent. Verify via `pnpm serve ads-schedule-viewer`
+  and confirm `trackFeature` fires on load/render/page-change/visual-click before closing the issue
+
+## reference-implementation
+
+- OWNS: the canonical pattern being mirrored
+- READS FROM: `equinor/fusion-core-apps` `apps/pbi-template`:
+  - `src/component/hooks/usePBIEventHandlers.ts` — builds the `Map<string, EventHandler>` and calls `trackFeature`
+  - `src/component/components/PowerBIReportView/PowerBIReportView.tsx` — passes `eventHandlers` to `<PowerBIEmbed>`
+  - `src/module/pbi/store/types.ts` — the `PowerBIEmbedEvents` enum (`loaded`/`rendered`/`error`/`buttonClicked`/`pageChanged`/`dataSelected`)
+- INVARIANT: cc-components has no shared `PowerBIEmbedEvents` enum; define a local one in `reportshared`
+  matching those string values exactly

--- a/.github/knowledge/domains/ads-reports.md
+++ b/.github/knowledge/domains/ads-reports.md
@@ -27,7 +27,7 @@ user-interaction tracking in the embedded reports).
 
 - OWNS: how an ADS report is filtered to the selected project
 - READS FROM: `currentContext.type.id === 'ProjectMaster'` → `pbi_context_mapping.ProjectMaster` = `{ table: 'Dim_ProjectMaster', column: 'ProjectMaster GUID' }`
-- WRITES FROM: a Power BI `IBasicFilter` with `values: [context.externalId]` applied to the embedded report
+- WRITES TO: a Power BI `IBasicFilter` with `values: [context.externalId]` applied to the embedded report
 - INVARIANT: the report will not render without a ProjectMaster context selected (guarded by `RootAppWrapper`)
 
 ## ads-interaction-tracking (cc-toolbox#4792)

--- a/.github/knowledge/power-bi-embedding.md
+++ b/.github/knowledge/power-bi-embedding.md
@@ -1,0 +1,66 @@
+---
+domain: power-bi-embedding
+related: [reports-architecture, ads-reports]
+---
+
+# Power BI Embedding Pipeline — Mental Model
+
+How a report's `PowerBiConfig` becomes a live embedded Power BI iframe. Spans three packages:
+`@cc-components/reportshared`, `@equinor/workspace-fusion` (local `libs/workspace/fusion`), and
+`@equinor/workspace-powerbi` (local `libs/workspace/power-bi`). Both `workspace-*` packages are
+**local workspace libraries**, not external npm deps — they can be edited directly.
+
+## end-to-end-flow
+
+- FLOW: `reports/<name>/main.tsx`
+  → `reportshared` `FusionReport` (`components/Report.tsx`) builds `powerBiOptions` via `usePBIOptions(reportId, ctxConfig)`
+  → `<Workspace powerBiOptions={pbi} modules={[powerBiModule]} usePowerBiFilters>` (`@equinor/workspace-fusion`)
+  → `powerBiModule.setup` (`libs/workspace/fusion/src/modules/power-bi/index.tsx`) creates a `PowerBiController` and renders `PowerBiWrapper`
+  → `PowerBiWrapper` renders `<PowerBI>` (`@equinor/workspace-powerbi`)
+  → `PowerBi.tsx` → `report/Report.tsx` (token + embed queries) → `loadedReport/LoadedReport.tsx`
+  → `<PowerBIEmbed>` from `powerbi-client-react` (the actual iframe)
+
+## usePBIOptions (reportshared)
+
+- OWNS: assembly of the `PowerBiConfig` object handed to the workspace (`src/hooks/usePBIOptions.tsx`)
+- READS FROM: `usePBIHelpers()` (`getEmbed`, `getToken`), the current Fusion context `externalId`, and an optional `{ table, column }` filter
+- WRITES TO: `{ getEmbed, getToken, reportUri, ErrorComponent, filters? }`
+- INVARIANT: when a context filter is supplied, `filters` targets `{ column, table }` with `values: [externalId]` — this is how a report is scoped to the selected project/facility
+- INVARIANT: `FusionReport` picks the filter table/column from `pbi_context_mapping` by `currentContext.type.id` (`Facility` → `Dim_Facility`/`Facility`; `ProjectMaster` → `Dim_ProjectMaster`/`ProjectMaster GUID`), unless an explicit `config` is passed
+
+## powerBiModule (workspace-fusion)
+
+- OWNS: the Fusion Workspace "Power BI" tab, its custom header, and the bookmark provider (`libs/workspace/fusion/src/modules/power-bi/index.tsx`)
+- READS FROM: `props.powerBiOptions` (the `PowerBiConfig`), `props.currentBookmark`, `props.usePowerBiFilters`
+- WRITES TO: a `PowerBiController` (with the basic filter), the rendered `<PowerBI>`, and the workspace bookmark payload's `powerBi` field
+- INVARIANT: if `powerBiOptions` is undefined the module no-ops (no tab)
+- INVARIANT: `createBasicFilter` converts `PowerBiConfig.filters` (`{ target, values }`) into a Power BI `IBasicFilter` (`filterType: 1`, `operator: 'In'`); non-string values are dropped
+- FLOW[bookmark-capture]: `PowerBiWrapper` subscribes to `controller.onReportReady`; on the embed it attaches `visualClicked` / `pageChanged` / `rendered` handlers that capture the bookmark state + active page and push it into the workspace bookmark payload (`updatePayload(old => ({ ...old, powerBi }))`)
+- TENSION: those three embed handlers exist for bookmark capture only — they do NOT emit analytics. Interaction tracking is a separate concern threaded via `eventHandlers` (see below)
+
+## PowerBiController (workspace-powerbi)
+
+- OWNS: the report-ready callback registry and active-page tracking (`libs/workspace/power-bi/src/lib/classes/powerBiController.ts`)
+- READS FROM: the embedded `Report` once loaded, `pageChanged` events
+- WRITES TO: `activePage`, `onActivePageChanged` observers, and every registered `onReportReady` callback
+- INVARIANT: `reportReady(report)` is called once by `Report.tsx`'s `onReportReady`; it fans out to all registered callbacks and starts tracking the active page
+
+## PowerBi render + token lifecycle (workspace-powerbi)
+
+- OWNS: the embed/token fetch, error boundary, suspense, and iframe mount (`PowerBi.tsx` → `report/Report.tsx` → `loadedReport/LoadedReport.tsx`)
+- READS FROM: `getToken(reportUri)` and `getEmbedInfo(reportUri)` (React Query), plus optional `filters`/`bookmark`
+- WRITES TO: `<PowerBIEmbed embedConfig={...}>` and, on ready, applies bookmark state or filters and calls `controller.reportReady`
+- INVARIANT: the token query auto-refetches just before `expirationUtc` (`generateRefetchInterval`); embed url + reportId come from `getEmbedInfo`
+- INVARIANT: `LoadedReport` already emits an AppInsights `PowerBI Report Rendered` event (load-time only) via `window.ai` inside `getEmbeddedComponent`'s `rendered` handler — this is separate from Fusion analytics feature tracking
+- INVARIANT: `PowerBiBootstrap` preloads the Power BI iframe JS by bootstrapping a hidden `service.Service` against `https://app.powerbi.com/reportEmbed`
+
+## interaction-tracking (issue cc-toolbox#4792)
+
+- OWNS: user-interaction analytics for embedded ADS reports (the requested feature)
+- READS FROM: `useTrackFeature` from `@equinor/fusion-framework-react-app/analytics`
+- WRITES TO: `trackFeature('fusion-pbi:<event>', payload)` calls, matching `fusion-core-apps` `pbi-template` naming exactly
+- DECIDED: mirror `fusion-core-apps/apps/pbi-template` — a `usePBIEventHandlers` hook builds a `Map<string, EventHandler>` and passes it to `<PowerBIEmbed eventHandlers={...}>`. `powerbi-client-react`'s `PowerBIEmbed` already supports `eventHandlers?: Map<string, EventHandler>`
+- INVARIANT: event names (from the shared `PowerBIEmbedEvents` enum) must be exactly `loaded`, `rendered`, `error`, `buttonClicked`, `pageChanged`, `dataSelected`; feature name is `fusion-pbi:${event}`
+- INVARIANT: payloads mirror pbi-template — `loaded`/`rendered`/`error`/`buttonClicked`: `{ event: event?.detail, reportId }`; `pageChanged`: `{ newPage: event?.detail.newPage.displayName, reportId }`; `dataSelected`: `{ dataPoints: event?.detail.dataPoints, reportId }`
+- DECIDED: because the generic `workspace-*` libs must stay decoupled from Fusion analytics, the `eventHandlers` map is built in `reportshared` (which runs inside a fusion-framework-react-app) and threaded down: `PowerBiConfig.eventHandlers` → `powerBiModule` `PowerBiWrapper` → `<PowerBI eventHandlers>` → `Report` → `LoadedReport` → `<PowerBIEmbed eventHandlers>`. This scopes tracking to ADS reports only (workspace apps don't supply the map)
+- TENSION: `useTrackFeature` no-ops safely if the `analytics` provider is absent (it routes a telemetry exception instead) — the Fusion portal provides the provider at runtime, so no `enableAnalytics` call is required in `frameworkConfig.ts`. Verify telemetry actually fires in the portal before assuming it works

--- a/.github/knowledge/reports-architecture.md
+++ b/.github/knowledge/reports-architecture.md
@@ -1,0 +1,88 @@
+---
+domain: reports-architecture
+related: [ads-reports, power-bi-embedding]
+---
+
+# CC Reports — Mental Model
+
+Power BI analytics apps that live under `reports/*` in `equinor/cc-components`. Each is a thin
+Fusion-framework app shell that embeds a single Power BI report inside a Fusion Workspace. They
+are distinct from the workspace apps under `apps/*` (which have grid/garden/sidesheet). Reports
+render **only** a Power BI tab.
+
+## report-app-shell
+
+- OWNS: one deployable Fusion app bundle per report under `reports/<name>`
+- READS FROM: `@cc-components/reportshared` (`Report`, `configure`, `RootAppWrapper`, `createRender`)
+- WRITES TO: `dist/app-bundle.*` ES module consumed by the Fusion Project Portal
+- INVARIANT: `src/main.tsx` is the entire app — it renders `<RootAppWrapper><Report reportId={...} /></RootAppWrapper>` and exports `render = createRender(Wrapper, configure([...contextTypes]))`
+- INVARIANT: the only per-report inputs are the `reportId` string and the list of context types passed to `configure(...)`
+- INVARIANT: build is `tsc -b -f` then Vite lib build (`vite.config.ts`, `appType: 'custom'`, `formats: ['es']`, entry `./src/main.tsx`, output `app-bundle`), using the shared `InjectProcessPlugin` from `patches/process`
+- DECIDED: all report logic is centralized in `@cc-components/reportshared` so individual report folders stay near-empty (just `main.tsx`, `vite.config.ts`, `tsconfig.json`, `package.json`); adding a report = copy a folder and change `reportId` + context types
+
+## reportshared-package
+
+- OWNS: `libs/reportshared` (`@cc-components/reportshared`) — every report's shared runtime
+- READS FROM: `@equinor/workspace-fusion` (local lib), `@equinor/fusion-framework-react-app` (bookmark/http), `@equinor/fusion-framework-react-module-context`, `@tanstack/react-query`
+- WRITES TO: public exports in `src/index.ts` — `Report` (= `FusionReport`), `configure`, `createRender`, `RootAppWrapper`
+- INVARIANT: only these four symbols are exported; report folders must not reach into internal paths
+- FLOW: `main.tsx` → `RootAppWrapper` (context guard + QueryClient + ErrorBoundary) → `FusionReport` → `<Workspace>` with `powerBiModule`
+
+## createRender-bootstrap
+
+- OWNS: the Fusion app entry facade (`src/fusion-framework/createRender.tsx`)
+- READS FROM: `makeComponent` from `@equinor/fusion-framework-react-app`, the app React component, and Fusion `ComponentRenderArgs`
+- WRITES TO: a `(el, args) => teardown` render function; mounts a React 19 `createRoot` and returns an unmount teardown
+- INVARIANT: this is the shared bootstrap for every report; do not hand-roll `createRoot` in report folders
+
+## configure-framework
+
+- OWNS: per-report Fusion module enablement (`src/fusion-framework/frameworkConfig.ts`)
+- READS FROM: the array of context type strings passed from `main.tsx` (e.g. `['ProjectMaster']` or `['Facility','ProjectMaster']`)
+- WRITES TO: `enableBookmark(config)` and `enableContext(config, ...)` with `setContextType(contextTypes)` and an OData `setContextParameterFn` (search + `type in [...]`)
+- INVARIANT: bookmark and context modules are always enabled; the report is context-driven and cannot render without a selected context
+- TENSION: analytics is NOT enabled here today — the Fusion portal is expected to provide the `analytics` module at runtime (see `power-bi-embedding.md`)
+
+## root-app-wrapper
+
+- OWNS: the top-level UI guard (`src/components/RootAppWrapper.tsx`)
+- READS FROM: `useFusionContext()` (= `useModuleCurrentContext().currentContext`)
+- WRITES TO: renders "Please select a context" when no context; otherwise `StrictMode` + `QueryClientProvider` + `ErrorBoundary` (reset keyed on `context.id`) + `StyledDefaultLayout`
+- INVARIANT: no context selected ⇒ the report never mounts; the `ErrorBoundary` fallback is a bare "Report crashed"
+
+## service-discovery-http
+
+- OWNS: creation of the authenticated `reports` HTTP client (`src/hooks/useServiceDiscovery.ts`, consumed by `usePbiHelpers.ts`)
+- READS FROM: `useFramework().modules.serviceDiscovery`
+- WRITES TO: `serviceDisco.createClient('reports')` → `IHttpClient` scoped to the CC reports backend
+- INVARIANT: the only registered service-disco type is `'reports'`
+- FLOW: hook → `createClient('reports')` → `client.fetch('reports/<reportUri>/...')`
+
+## report-backend-contract
+
+- OWNS: the report backend endpoints consumed via the `reports` client (`usePbiHelpers.ts`, `useReportErrorInfo.ts`, `ReportMeta.tsx`)
+- READS FROM: `reports/<id>/config/embedinfo` (embed url + reportId), `reports/<id>/token` (Power BI token + `expirationUtc`), `reports/<id>` (`ReportInfo` metadata), `reports/<id>/contexts/<externalId>/contexttypes/<typeId>/checkaccess` (OPTIONS access probe), plus `rlsrequirements` / `description/content` / `accessdescription/content` for error UX
+- WRITES TO: `EmbedInfo`, `EmbedToken`, `ReportInfo` typed objects (`src/types/types.ts`)
+- INVARIANT: `getEmbed` fires the access check (`checkAccess`, OPTIONS) in parallel with `embedinfo` and awaits it before returning; a `403` throws with the `Response` as `error.cause`
+- FLOW[error-UX]: a thrown error with `Response` cause of `401/403` → `ErrorComponent` renders `AccessErrorComponent` (which uses `useReportErrorInfo` to fetch RLS/description/owner); other errors → "Failed to load report"
+
+## report-bookmarks
+
+- OWNS: bookmark capture/restore for the embedded report (`src/hooks/useWorkspaceBookmark.ts`)
+- READS FROM: `useCurrentBookmark` / `useBookmark` from `@equinor/fusion-framework-react-app/bookmark`
+- WRITES TO: `currentBookmark` (payload), `bookmarkKey` (id), and an `onBookmarkChange` setter passed to `<Workspace>`
+- INVARIANT: the `<Workspace key={contextId + bookmarkKey}>` remounts when context or bookmark id changes, so a bookmark load fully re-initializes the report
+- FLOW: Power BI page/visual/bookmark state is captured by the `powerBiModule` and stored into the workspace bookmark payload's `powerBi` field (see `power-bi-embedding.md`)
+
+## report-inventory
+
+- OWNS: the set of reports and their context typing
+- INVARIANT: ADS reports (`configure(['ProjectMaster'])`, ProjectMaster-only): `ads-schedule-viewer`, `ads-weekly-meeting`, `ads-monthly-meeting`, `ads-commercial-meeting`, `ads-engineering-meeting`, `ads-offshore-installation` (reportId `ads-offshore-installation-trends`)
+- INVARIANT: most non-ADS reports use `configure(['Facility','ProjectMaster'])` (e.g. `checklist`, `tags`, `ccoverview`, `activities`, `atex-inspection`, `commissioning-task`, `preservation-workspace`, `query-workspace`, `workorder-area-overview`, `projectsafetybarriers`, `completion-analytics` (reportId `pp-cch-overview`))
+- INVARIANT: the folder name and the `reportId` are NOT always identical — always read `main.tsx` for the real `reportId`
+
+## report-deploy
+
+- OWNS: PR-preview and production release of each report bundle
+- READS FROM: `github-action/src/releasePr.ts` (`pr:deploy`) and `github-action/src/releaseMain.ts` (`fprd:deploy`), invoked via each report's `package.json` scripts
+- INVARIANT: report `package.json` scripts are uniform: `dev` (`fusion-framework-cli app dev`), `build` (`tsc -b -f`), `pr:deploy`, `fprd:deploy`

--- a/.github/skills/knowledge-builder/SKILL.md
+++ b/.github/skills/knowledge-builder/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: knowledge-builder
+description: Post-task lessons-learned review. Updates knowledge, instruction, and skill files to continuously improve future sessions.
+---
+
+# knowledge-builder
+
+After any non-trivial task (feature, bugfix, refactor, debugging session),
+run this knowledge-builder.
+
+## Step 1 — Reflect
+
+- What went well? (efficient patterns, tools, approaches)
+- What went poorly? (wasted effort, wrong assumptions, dead ends)
+- What was surprising? (undocumented quirks, gotchas)
+- What was missing from instructions/knowledge? (would have saved time)
+- What instructions were wrong or outdated?
+
+## Step 2 — Classify (decision tree, in order)
+
+### 2a. Should we fix this instead of documenting it?
+
+If the lesson is "this is unnecessarily hard," consider whether the root
+cause can be eliminated (rename, better default, small refactor). File an
+issue instead of (or in addition to) documenting the workaround.
+
+### 2b. Does this belong in the code itself?
+
+- Inline comment: implementation gotcha tied to a specific line
+- JSDoc: public API contract, non-obvious parameter semantics
+- Type-level doc: property whose name alone is misleading
+
+If someone would need to leave the file to understand the code, the comment
+is missing.
+
+### 2c. Does this update the mental model? → `knowledge/`
+
+Route here when the lesson describes:
+
+- How subsystems connect or communicate
+- Why something is designed the way it is
+- An invariant that must hold
+- A known tension or pressure point
+- An end-to-end operation trace
+
+Use the structured notation (OWNS / READS FROM / WRITES TO / INVARIANT /
+FLOW / TENSION / DECIDED).
+
+### 2d. Is it a rule for working in a file type? → `instructions/`
+
+Conventions, naming rules, lint patterns, framework idioms. Add `applyTo`
+glob frontmatter so it auto-loads for matching files.
+
+### 2e. Is it a multi-step workflow? → `skills/<name>/SKILL.md`
+
+A repeatable procedure with multiple steps (release prep, debugging flow,
+new-component scaffolding).
+
+## Step 3 — Apply
+
+Make the documentation update in the same commit (or a follow-up) and
+reference it in the commit message.


### PR DESCRIPTION
## What

Adds a `.github/knowledge/` folder with structured mental-model notes for the reports side of `cc-components`, plus the `knowledge-builder` skill used to structure them.

Seeded while investigating [cc-toolbox#4792](https://github.com/equinor/cc-toolbox/issues/4792) (enable user-interaction tracking in embedded ADS Power BI reports).

## Files

```
.github/knowledge/
├── README.md                   # Index + notation legend
├── reports-architecture.md     # reports/* shells + @cc-components/reportshared runtime
├── power-bi-embedding.md       # Embed pipeline: reportshared → workspace-fusion → workspace-powerbi → PowerBIEmbed
└── domains/
    └── ads-reports.md          # ADS report set + cc-toolbox#4792 tracking design
.github/skills/
└── knowledge-builder/SKILL.md  # Post-task lessons-learned skill (pattern source)
```

## Notation

All entries use the knowledge-builder structured notation: **OWNS / READS FROM / WRITES TO / INVARIANT / FLOW / TENSION / DECIDED**.

## Notes

- Docs only — no runtime/build changes.
- Content is drawn from reading the report shells, `reportshared`, and the local `workspace-fusion` / `workspace-powerbi` libs, plus the `fusion-core-apps/pbi-template` reference.
- The #4792 tracking approach is documented as `DECIDED`/`TENSION` (design), not as implemented code — implementation is a separate PR.

Related: equinor/cc-toolbox#4792