### PR TITLE
feat: track user interactions in embedded ADS Power BI reports

### DIFF
--- a/libs/reportshared/src/hooks/usePBIEventHandlers.ts
+++ b/libs/reportshared/src/hooks/usePBIEventHandlers.ts
@@ -1,0 +1,96 @@
+import { useMemo } from 'react';
+import { EventHandler } from '@equinor/workspace-fusion/power-bi';
+import { useTrackFeature } from '@equinor/fusion-framework-react-app/analytics';
+
+/**
+ * Power BI embed event names.
+ *
+ * Values MUST match `equinor/fusion-core-apps` `pbi-template` (`PowerBIEmbedEvents`)
+ * so tracked features stay consistent across Fusion apps.
+ */
+export enum PowerBIEmbedEvents {
+  Loaded = 'loaded',
+  Rendered = 'rendered',
+  Error = 'error',
+  ButtonClicked = 'buttonClicked',
+  PageChanged = 'pageChanged',
+  DataSelected = 'dataSelected',
+}
+
+/**
+ * Builds the Power BI embed event handler map that reports user interactions to the
+ * Fusion analytics module via `useTrackFeature`.
+ *
+ * Mirrors `fusion-core-apps/apps/pbi-template` — feature name is `fusion-pbi:<event>`
+ * and payloads match that implementation for cross-app consistency.
+ *
+ * `useTrackFeature` no-ops safely when no analytics provider is configured, so this is
+ * safe to attach unconditionally; the Fusion portal supplies the provider at runtime.
+ *
+ * @param reportId - The report identifier included in every tracked event.
+ * @returns A `Map<string, EventHandler>` to pass to the workspace `powerBiOptions.eventHandlers`.
+ */
+export const usePBIEventHandlers = (reportId: string): Map<string, EventHandler> => {
+  const trackFeature = useTrackFeature();
+
+  return useMemo(
+    () =>
+      new Map<string, EventHandler>([
+        [
+          PowerBIEmbedEvents.Loaded,
+          (event) => {
+            trackFeature(`fusion-pbi:${PowerBIEmbedEvents.Loaded}`, {
+              event: event?.detail,
+              reportId,
+            });
+          },
+        ],
+        [
+          PowerBIEmbedEvents.Rendered,
+          (event) => {
+            trackFeature(`fusion-pbi:${PowerBIEmbedEvents.Rendered}`, {
+              event: event?.detail,
+              reportId,
+            });
+          },
+        ],
+        [
+          PowerBIEmbedEvents.Error,
+          (event) => {
+            trackFeature(`fusion-pbi:${PowerBIEmbedEvents.Error}`, {
+              event: event?.detail,
+              reportId,
+            });
+          },
+        ],
+        [
+          PowerBIEmbedEvents.ButtonClicked,
+          (event) => {
+            trackFeature(`fusion-pbi:${PowerBIEmbedEvents.ButtonClicked}`, {
+              event: event?.detail,
+              reportId,
+            });
+          },
+        ],
+        [
+          PowerBIEmbedEvents.PageChanged,
+          (event) => {
+            trackFeature(`fusion-pbi:${PowerBIEmbedEvents.PageChanged}`, {
+              newPage: event?.detail?.newPage?.displayName,
+              reportId,
+            });
+          },
+        ],
+        [
+          PowerBIEmbedEvents.DataSelected,
+          (event) => {
+            trackFeature(`fusion-pbi:${PowerBIEmbedEvents.DataSelected}`, {
+              dataPoints: event?.detail?.dataPoints,
+              reportId,
+            });
+          },
+        ],
+      ]),
+    [trackFeature, reportId]
+  );
+};

--- a/libs/reportshared/src/hooks/usePBIEventHandlers.ts
+++ b/libs/reportshared/src/hooks/usePBIEventHandlers.ts
@@ -2,12 +2,6 @@ import { useMemo } from 'react';
 import { EventHandler } from '@equinor/workspace-fusion/power-bi';
 import { useTrackFeature } from '@equinor/fusion-framework-react-app/analytics';
 
-/**
- * Power BI embed event names.
- *
- * Values MUST match `equinor/fusion-core-apps` `pbi-template` (`PowerBIEmbedEvents`)
- * so tracked features stay consistent across Fusion apps.
- */
 export enum PowerBIEmbedEvents {
   Loaded = 'loaded',
   Rendered = 'rendered',
@@ -17,19 +11,6 @@ export enum PowerBIEmbedEvents {
   DataSelected = 'dataSelected',
 }
 
-/**
- * Builds the Power BI embed event handler map that reports user interactions to the
- * Fusion analytics module via `useTrackFeature`.
- *
- * Mirrors `fusion-core-apps/apps/pbi-template` — feature name is `fusion-pbi:<event>`
- * and payloads match that implementation for cross-app consistency.
- *
- * `useTrackFeature` no-ops safely when no analytics provider is configured, so this is
- * safe to attach unconditionally; the Fusion portal supplies the provider at runtime.
- *
- * @param reportId - The report identifier included in every tracked event.
- * @returns A `Map<string, EventHandler>` to pass to the workspace `powerBiOptions.eventHandlers`.
- */
 export const usePBIEventHandlers = (reportId: string): Map<string, EventHandler> => {
   const trackFeature = useTrackFeature();
 

--- a/libs/reportshared/src/hooks/usePBIOptions.tsx
+++ b/libs/reportshared/src/hooks/usePBIOptions.tsx
@@ -1,6 +1,7 @@
 import { PowerBiConfig } from '@equinor/workspace-fusion/power-bi';
 import { usePBIHelpers } from './usePbiHelpers';
 import { useFusionContext } from './useContext';
+import { usePBIEventHandlers } from './usePBIEventHandlers';
 import { ReportMeta } from '../components/ReportMeta';
 import { ErrorComponent } from '../components/ErrorComponent/ErrorComponent';
 
@@ -17,6 +18,7 @@ export type Filters = {
 export function usePBIOptions(reportUri: string, filters?: Filters): PowerBiConfig {
   const { getEmbed, getToken } = usePBIHelpers();
   const externalId = useFusionContext()?.externalId;
+  const eventHandlers = usePBIEventHandlers(reportUri);
 
   return {
     getEmbed,
@@ -29,5 +31,6 @@ export function usePBIOptions(reportUri: string, filters?: Filters): PowerBiConf
       : undefined,
     reportUri,
     ErrorComponent,
+    eventHandlers,
   };
 }

--- a/libs/workspace/fusion/src/lib/integrations/power-bi/power-bi.ts
+++ b/libs/workspace/fusion/src/lib/integrations/power-bi/power-bi.ts
@@ -9,6 +9,7 @@ import {
   Callback,
   CompareFunc,
   ContextErrorType,
+  EventHandler,
   FusionEmbedConfig,
   FusionPBIError,
   FusionPowerBiToken,
@@ -28,6 +29,7 @@ export type {
   Callback,
   CompareFunc,
   ContextErrorType,
+  EventHandler,
   FusionPBIError,
   GetPowerBiEmbedConfig,
   IReportEmbedConfiguration,
@@ -72,6 +74,11 @@ type PowerBiConfig = {
   ErrorComponent: React.ComponentType<ErrorComponentProps>;
   filters?: FilterConfig;
   getClassification?: (reportUri: string, signal?: AbortSignal) => Promise<string>;
+  /**
+   * Optional Power BI embed event handlers (e.g. loaded, rendered, pageChanged)
+   * used for interaction tracking. Forwarded to the underlying <PowerBIEmbed />.
+   */
+  eventHandlers?: Map<string, EventHandler>;
 };
 
 export type ReportMetaDataProps = {

--- a/libs/workspace/fusion/src/lib/integrations/power-bi/power-bi.ts
+++ b/libs/workspace/fusion/src/lib/integrations/power-bi/power-bi.ts
@@ -74,10 +74,6 @@ type PowerBiConfig = {
   ErrorComponent: React.ComponentType<ErrorComponentProps>;
   filters?: FilterConfig;
   getClassification?: (reportUri: string, signal?: AbortSignal) => Promise<string>;
-  /**
-   * Optional Power BI embed event handlers (e.g. loaded, rendered, pageChanged)
-   * used for interaction tracking. Forwarded to the underlying <PowerBIEmbed />.
-   */
   eventHandlers?: Map<string, EventHandler>;
 };
 

--- a/libs/workspace/fusion/src/modules/power-bi/index.tsx
+++ b/libs/workspace/fusion/src/modules/power-bi/index.tsx
@@ -158,6 +158,7 @@ const PowerBiWrapper = (powerBiConfig: PowerBiConfig & { controller: PowerBiCont
       reportUri={powerBiConfig.reportUri}
       filters={createBasicFilter(powerBiConfig.filters)}
       ErrorComponent={powerBiConfig.ErrorComponent}
+      eventHandlers={powerBiConfig.eventHandlers}
     />
   );
 };

--- a/libs/workspace/power-bi/src/index.ts
+++ b/libs/workspace/power-bi/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib';
 import { IReportEmbedConfiguration, models, Report, Embed } from 'powerbi-client';
+import type { EventHandler } from 'powerbi-client-react';
 type IBasicFilter = models.IBasicFilter;
-export type { IReportEmbedConfiguration, IBasicFilter, Report, Embed };
+export type { IReportEmbedConfiguration, IBasicFilter, Report, Embed, EventHandler };

--- a/libs/workspace/power-bi/src/lib/components/PowerBi.tsx
+++ b/libs/workspace/power-bi/src/lib/components/PowerBi.tsx
@@ -29,10 +29,6 @@ export interface PowerBiProps {
   filters?: models.IBasicFilter;
   bookmark?: string;
   controller: PowerBiController;
-  /**
-   * Optional Power BI embed event handlers (e.g. loaded, rendered, pageChanged).
-   * Forwarded to the underlying <PowerBIEmbed eventHandlers />.
-   */
   eventHandlers?: Map<string, EventHandler>;
 }
 

--- a/libs/workspace/power-bi/src/lib/components/PowerBi.tsx
+++ b/libs/workspace/power-bi/src/lib/components/PowerBi.tsx
@@ -11,6 +11,7 @@ import { Report } from './report/Report';
 
 import React from 'react';
 import { models, factories, service } from 'powerbi-client';
+import { EventHandler } from 'powerbi-client-react';
 import styled from 'styled-components';
 import { StyledLoadingWrapper } from './loading/loading.styles';
 
@@ -28,6 +29,11 @@ export interface PowerBiProps {
   filters?: models.IBasicFilter;
   bookmark?: string;
   controller: PowerBiController;
+  /**
+   * Optional Power BI embed event handlers (e.g. loaded, rendered, pageChanged).
+   * Forwarded to the underlying <PowerBIEmbed eventHandlers />.
+   */
+  eventHandlers?: Map<string, EventHandler>;
 }
 
 const client = new QueryClient();

--- a/libs/workspace/power-bi/src/lib/components/loadedReport/LoadedReport.tsx
+++ b/libs/workspace/power-bi/src/lib/components/loadedReport/LoadedReport.tsx
@@ -11,10 +11,6 @@ const defaultAspectRatio = 0.41;
 interface LoadedReportProps {
   config: IReportEmbedConfiguration;
   onReportReady?: (rep: Report) => void;
-  /**
-   * Optional Power BI embed event handlers (e.g. analytics tracking).
-   * Merged with the internal `loaded`/`rendered` handlers so both fire.
-   */
   eventHandlers?: Map<string, EventHandler>;
 }
 export const LoadedReport = ({ config, onReportReady, eventHandlers }: LoadedReportProps) => {
@@ -42,12 +38,6 @@ export const LoadedReport = ({ config, onReportReady, eventHandlers }: LoadedRep
     }
   }
 
-  /**
-   * PowerBIEmbed's `setEventHandlers` calls `embed.off(event)` for every event in the
-   * map before (re)attaching, so the internal `loaded`/`rendered` handlers cannot be
-   * registered separately (e.g. via `getEmbeddedComponent`) — they would be clobbered.
-   * Instead, keep them in this map and compose with any externally provided handlers.
-   */
   const mergedEventHandlers = useMemo(() => {
     const internal = new Map<string, EventHandler>([
       [
@@ -76,7 +66,6 @@ export const LoadedReport = ({ config, onReportReady, eventHandlers }: LoadedRep
       }
     });
     return merged;
-    // trackReportLoadTime/onReportReady are stable in behavior; config drives re-embeds.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [eventHandlers, onReportReady, config]);
 

--- a/libs/workspace/power-bi/src/lib/components/loadedReport/LoadedReport.tsx
+++ b/libs/workspace/power-bi/src/lib/components/loadedReport/LoadedReport.tsx
@@ -1,7 +1,7 @@
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 import { IReportEmbedConfiguration, Report } from 'powerbi-client';
-import { PowerBIEmbed } from 'powerbi-client-react';
-import { useEffect, useRef, useState } from 'react';
+import { PowerBIEmbed, EventHandler } from 'powerbi-client-react';
+import { useEffect, useMemo, useRef } from 'react';
 import styled from 'styled-components';
 import { StyledReportRoot, StyledReportContainer } from '../powerbi.styles';
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
@@ -11,8 +11,13 @@ const defaultAspectRatio = 0.41;
 interface LoadedReportProps {
   config: IReportEmbedConfiguration;
   onReportReady?: (rep: Report) => void;
+  /**
+   * Optional Power BI embed event handlers (e.g. analytics tracking).
+   * Merged with the internal `loaded`/`rendered` handlers so both fire.
+   */
+  eventHandlers?: Map<string, EventHandler>;
 }
-export const LoadedReport = ({ config, onReportReady }: LoadedReportProps) => {
+export const LoadedReport = ({ config, onReportReady, eventHandlers }: LoadedReportProps) => {
   const ref = useRef<HTMLDivElement | null>(null);
   const [width] = useResizeObserver(ref);
   const appInsights = (window as any).ai as ApplicationInsights | undefined;
@@ -37,6 +42,44 @@ export const LoadedReport = ({ config, onReportReady }: LoadedReportProps) => {
     }
   }
 
+  /**
+   * PowerBIEmbed's `setEventHandlers` calls `embed.off(event)` for every event in the
+   * map before (re)attaching, so the internal `loaded`/`rendered` handlers cannot be
+   * registered separately (e.g. via `getEmbeddedComponent`) — they would be clobbered.
+   * Instead, keep them in this map and compose with any externally provided handlers.
+   */
+  const mergedEventHandlers = useMemo(() => {
+    const internal = new Map<string, EventHandler>([
+      [
+        'loaded',
+        (_event, embeddedEntity) => {
+          if (embeddedEntity) {
+            onReportReady?.(embeddedEntity as Report);
+          }
+        },
+      ],
+      ['rendered', () => trackReportLoadTime()],
+    ]);
+
+    if (!eventHandlers) return internal;
+
+    const merged = new Map<string, EventHandler>(internal);
+    eventHandlers.forEach((handler, event) => {
+      const existing = merged.get(event);
+      if (existing && handler) {
+        merged.set(event, (e, entity) => {
+          existing(e, entity);
+          handler(e, entity);
+        });
+      } else {
+        merged.set(event, handler);
+      }
+    });
+    return merged;
+    // trackReportLoadTime/onReportReady are stable in behavior; config drives re-embeds.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventHandlers, onReportReady, config]);
+
   return (
     <StyledReportRoot id={'reportRoot'} ref={ref}>
       <StyledReportContainer>
@@ -45,13 +88,7 @@ export const LoadedReport = ({ config, onReportReady }: LoadedReportProps) => {
             <PowerBIEmbed
               cssClassName="pbiEmbed"
               embedConfig={config}
-              getEmbeddedComponent={(embed) => {
-                embed.on('loaded', () => {
-                  onReportReady && onReportReady(embed as Report);
-                });
-                embed.off('rendered', trackReportLoadTime);
-                embed.on('rendered', trackReportLoadTime);
-              }}
+              eventHandlers={mergedEventHandlers}
             />
           </PowerBiWrapper>
         </StyledAspectRatio>

--- a/libs/workspace/power-bi/src/lib/components/report/Report.tsx
+++ b/libs/workspace/power-bi/src/lib/components/report/Report.tsx
@@ -15,7 +15,7 @@ const StyledLoadingWrapper = styled.div`
   justify-content: center;
 `;
 
-export function Report({ getEmbedInfo, getToken, reportUri, controller, filters, bookmark }: PowerBiProps) {
+export function Report({ getEmbedInfo, getToken, reportUri, controller, filters, bookmark, eventHandlers }: PowerBiProps) {
   const {
     data: token,
     isLoading: isTokenLoading,
@@ -62,6 +62,7 @@ export function Report({ getEmbedInfo, getToken, reportUri, controller, filters,
   return (
     <LoadedReport
       config={generateEmbedConfig(embed, token.token, filters)}
+      eventHandlers={eventHandlers}
       onReportReady={(rep) => {
         if (bookmark) {
           rep.bookmarksManager.applyState(bookmark);


### PR DESCRIPTION
## What

Enables **user-interaction tracking** in the embedded **ADS** Power BI reports (`reports/ads-*`) in cc-components, mirroring the existing implementation in `equinor/fusion-core-apps` `pbi-template`.

closes equinor/cc-toolbox#4792


## Why

The ADS Power BI reports embedded in the Fusion Project Portal did not report user interactions (load, render, page change, visual click, data selection) to the Fusion analytics module. This makes the tracking consistent with other Fusion apps.

## How

An optional `eventHandlers` map is threaded from the report config down to the underlying `<PowerBIEmbed>` component. The map is built in `@cc-components/reportshared` (which runs inside a `fusion-framework-react-app`, where `useTrackFeature` is available), keeping the generic workspace libraries decoupled from Fusion analytics.

### Changes

- **`@cc-components/reportshared`**
  - New `usePBIEventHandlers` hook using `useTrackFeature` from `@equinor/fusion-framework-react-app/analytics`. It mirrors `fusion-core-apps/apps/pbi-template` exactly — feature name `fusion-pbi:<event>`, the same event names (`loaded`, `rendered`, `error`, `buttonClicked`, `pageChanged`, `dataSelected`) and the same payload shapes — so tracked features stay consistent across Fusion apps.
  - Wired into `usePBIOptions`, so every report using it (all ADS reports) gets tracking.
- **`@equinor/workspace-fusion`**
  - Added optional `eventHandlers` to `PowerBiConfig` and forward it in `PowerBiWrapper`; re-export the `EventHandler` type.
- **`@equinor/workspace-powerbi`**
  - Thread `eventHandlers` through `PowerBi` → `Report` → `LoadedReport`.
  - **Important:** `LoadedReport` merges the internal `loaded`/`rendered` handlers (report-ready callback + AppInsights load-time tracking) with any external handlers into a **single** map. `PowerBIEmbed.setEventHandlers` calls `embed.off(event)` before re-attaching, so keeping the internal handlers separate would clobber them — merging avoids this.

### Notes

- No app-level config change is required: `useTrackFeature` no-ops safely when no analytics provider is present, and the Fusion portal supplies the `analytics` module at runtime (same as fusion-core-apps).
- No dependency or lockfile changes — the `/analytics` subpath resolves via the existing `@equinor/fusion-framework-react-app` used by `reportshared`.

## Verification

- ✅ Full monorepo build passes (`pnpm build` — 60/60 packages), including the affected workspace libs, `reportshared`, all ADS reports, and the CC apps (e.g. `swcrapp`).
- ⚠️ Full runtime telemetry verification requires the Fusion portal (auth + browser) and could not be performed headlessly; the tracking will fire once deployed to the portal where the analytics provider is present.

## Related

- Docs: knowledge base for CC reports and ADS Power BI embedding — #1317